### PR TITLE
Updates package.json 'bug' field to point to this repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/textmate/php.tmbundle/issues"
+    "url": "https://github.com/atom/language-php/issues"
   }
 }


### PR DESCRIPTION
Very minor, but the 'bugs' field in package.json was still pointing to the TextMate bundle this package was generated from.
