### PR TITLE
Add versions of 'this' and 'ethis' snippets that work inside of php tags

### DIFF
--- a/snippets/language-php.cson
+++ b/snippets/language-php.cson
@@ -89,6 +89,12 @@
   'case …':
     'prefix': 'case'
     'body': 'case \'${1:variable}\':\n\t${0:# code...}\n\tbreak;'
+  '$this->…':
+    'prefix': 'this'
+    'body': '$this->$0'
+  'echo $this->…':
+    'prefix': 'ethis'
+    'body': 'echo $this->$0'
   'Throw Exception':
     'prefix': 'throw'
     'body': 'throw new $1Exception(${2:"${3:Error Processing Request}"}${4:, ${5:1}});\n$0'


### PR DESCRIPTION
this + tab and ethis + tab was wrapping their snippet in <?php  ?> even when already in source. I added the equivalent snippets so that they would work within <?php tags.
