### PR TITLE
Added *install* and *profile* extensions are valid PHP files.

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -5,6 +5,8 @@
   'ctp'
   'inc'
   'module'
+  'install'
+  'profile'
   'php'
   'php3'
   'php4'


### PR DESCRIPTION
[Drupal](https://drupal.org) use this extensions to manage installation files and distribution profile.
- More info about [.install](https://drupal.org/node/876250) file extension.
- More info about [.profile](https://drupal.org/node/1022020) file extension.
