### PR TITLE
Properly identify finally keyword

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -906,7 +906,7 @@
         ]
       }
       {
-        'match': '\\b(catch|try|throw|exception)\\b'
+        'match': '\\b(catch|try|throw|exception|finally)\\b'
         'name': 'keyword.control.exception.php'
       }
       {


### PR DESCRIPTION
This properly identifies "finally" as an exception keyword instead of a constant.