### PR TITLE
Adding semicolons after control structures in .text.html.

### DIFF
--- a/snippets/language-php.cson
+++ b/snippets/language-php.cson
@@ -123,19 +123,19 @@
     'body': '<?php echo ${1:$var} ?>$0'
   '<?php echo htmlentities(…) ?>':
     'prefix': 'echoh'
-    'body': '<?php echo htmlentities(${1:$var}, ENT_QUOTES, \'utf-8\') ?>$0'
+    'body': '<?php echo htmlentities(${1:$var}, ENT_QUOTES, \'utf-8\'); ?>$0'
   '<?php else: ?>':
     'prefix': 'else'
     'body': '<?php else: ?>'
   '<?php foreach (…) … <?php endforeach ?>':
     'prefix': 'foreach'
-    'body': '<?php foreach ($${1:variable} as $${2:key}${3: => $${4:value}}): ?>\n\t${0}\n<?php endforeach ?>'
+    'body': '<?php foreach ($${1:variable} as $${2:key}${3: => $${4:value}}): ?>\n\t${0}\n<?php endforeach; ?>'
   '<?php if (…) ?> … <?php else ?> … <?php endif ?>':
     'prefix': 'ifelse'
-    'body': '<?php if (${1:condition}): ?>\n\t$2\n<?php else: ?>\n\t$0\n<?php endif ?>'
+    'body': '<?php if (${1:condition}): ?>\n\t$2\n<?php else: ?>\n\t$0\n<?php endif; ?>'
   '<?php if (…) ?> … <?php endif ?>':
     'prefix': 'if'
-    'body': '<?php if (${1:condition}): ?>\n\t$0\n<?php endif ?>'
+    'body': '<?php if (${1:condition}): ?>\n\t$0\n<?php endif; ?>'
   'var_dump("…")':
     'prefix': 'dump'
     'body': 'var_dump($1);$0'


### PR DESCRIPTION
While not required in the scenario of html/php, ending semicolons make it easier to add new code within existing PHP tags. I had thought that some coding standards mandated this, but I didn't find a supporting case so there is that caveat. Thanks for taking a look.