### PR TITLE
Fixed so namespaces syntax works on same lime as <?php

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -314,6 +314,39 @@
         ]
       }
       {
+        'begin': '(?x)\n\t\t\t\t\t\t\t\\s*(array) # Typehint\n\t\t\t\t\t\t\t\\s*(&)? \t\t\t\t\t# Reference\n\t\t\t\t\t\t\t\\s*((\\$+)[a-zA-Z_\\x{7f}-\\x{ff}][a-zA-Z0-9_\\x{7f}-\\x{ff}]*) # The variable name\n\t\t\t\t\t\t\t\\s*(=)\t# A default value\n\t\t\t\t\t\t\t\\s*\\\[\n\t\t\t\t\t\t\t'
+        'beginCaptures':
+          '1':
+            'name': 'storage.type.php'
+          '2':
+            'name': 'storage.modifier.reference.php'
+          '3':
+            'name': 'variable.other.php'
+          '4':
+            'name': 'punctuation.definition.variable.php'
+          '5':
+            'name': 'support.function.construct.php'
+          '6':
+            'name': 'punctuation.definition.short.array.begin.php'
+        'contentName': 'meta.array.php'
+        'end': '\\\]'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.short.array.end.php'
+        'name': 'meta.function.argument.short.array.php'
+        'patterns': [
+          {
+            'include': '#comments'
+          }
+          {
+            'include': '#strings'
+          }
+          {
+            'include': '#numbers'
+          }
+        ]
+      }
+      {
         'captures':
           '1':
             'name': 'storage.type.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -756,7 +756,7 @@
         ]
       }
       {
-        'begin': '(?i)(?:^\\s*|\\s)(namespace)\\b\\s+(?=([a-z0-9_\\\\]+\\s*($|[;{]|(\\/[\\/*])))|$)'
+        'begin': '(?i)(?:^\\s*|\\s*)(namespace)\\b\\s+(?=([a-z0-9_\\\\]+\\s*($|[;{]|(\\/[\\/*])))|$)'
         'beginCaptures':
           '1':
             'name': 'keyword.other.namespace.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -756,9 +756,9 @@
         ]
       }
       {
-        'begin': '(?i)(^\\s*|\\s)(namespace)\\b\\s+(?=([a-z0-9_\\\\]+\\s*($|[;{]|(\\/[\\/*])))|$)'
+        'begin': '(?i)(?:^\\s*|\\s)(namespace)\\b\\s+(?=([a-z0-9_\\\\]+\\s*($|[;{]|(\\/[\\/*])))|$)'
         'beginCaptures':
-          '2':
+          '1':
             'name': 'keyword.other.namespace.php'
         'contentName': 'entity.name.type.namespace.php'
         'end': '(?i)(?=\\s*$|[^a-z0-9_\\\\])'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -314,41 +314,6 @@
         ]
       }
       {
-        'begin': '(?x)\n\t\t\t\t\t\t\t\\s*(array) # Typehint\n\t\t\t\t\t\t\t\\s*(&)? \t\t\t\t\t# Reference\n\t\t\t\t\t\t\t\\s*((\\$+)[a-zA-Z_\\x{7f}-\\x{ff}][a-zA-Z0-9_\\x{7f}-\\x{ff}]*) # The variable name\n\t\t\t\t\t\t\t\\s*(=)\t# A default value\n\t\t\t\t\t\t\t\\s*\\\[\n\t\t\t\t\t\t\t'
-        'beginCaptures':
-          '1':
-            'name': 'storage.type.php'
-          '2':
-            'name': 'storage.modifier.reference.php'
-          '3':
-            'name': 'variable.other.php'
-          '4':
-            'name': 'punctuation.definition.variable.php'
-          '5':
-            'name': ''
-          '6':
-            'name': 'support.function.construct.php'
-          '7':
-            'name': 'punctuation.definition.short.array.begin.php'
-        'contentName': 'meta.array.php'
-        'end': '\\\]'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.short.array.end.php'
-        'name': 'meta.function.argument.short.array.php'
-        'patterns': [
-          {
-            'include': '#comments'
-          }
-          {
-            'include': '#strings'
-          }
-          {
-            'include': '#numbers'
-          }
-        ]
-      }
-      {
         'captures':
           '1':
             'name': 'storage.type.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -756,9 +756,9 @@
         ]
       }
       {
-        'begin': '(?i)^\\s*(namespace)\\b\\s+(?=([a-z0-9_\\\\]+\\s*($|[;{]|(\\/[\\/*])))|$)'
+        'begin': '(?i)(^\\s*|\\s)(namespace)\\b\\s+(?=([a-z0-9_\\\\]+\\s*($|[;{]|(\\/[\\/*])))|$)'
         'beginCaptures':
-          '1':
+          '2':
             'name': 'keyword.other.namespace.php'
         'contentName': 'entity.name.type.namespace.php'
         'end': '(?i)(?=\\s*$|[^a-z0-9_\\\\])'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -325,8 +325,10 @@
           '4':
             'name': 'punctuation.definition.variable.php'
           '5':
-            'name': 'support.function.construct.php'
+            'name': ''
           '6':
+            'name': 'support.function.construct.php'
+          '7':
             'name': 'punctuation.definition.short.array.begin.php'
         'contentName': 'meta.array.php'
         'end': '\\\]'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -196,3 +196,18 @@ describe 'PHP grammar', ->
         expect(tokens[1][4]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
         expect(tokens[1][5]).toEqual value: '2', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'constant.numeric.php']
         expect(tokens[1][6]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
+
+      it 'should tokenize namespace at the same line as <?php', ->
+        tokens = grammar.tokenizeLines "<?php namespace Test;"
+        expect(tokens[0][1]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.namespace.php']
+        expect(tokens[0][2]).toEqual value: 'namespace', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.namespace.php', 'keyword.other.namespace.php']
+        expect(tokens[0][3]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.namespace.php']
+        expect(tokens[0][4]).toEqual value: 'Test', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.namespace.php', 'entity.name.type.namespace.php']
+        expect(tokens[0][5]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
+
+      it 'should tokenize namespace correctly', ->
+        tokens = grammar.tokenizeLines "<?php\nnamespace Test;"
+        expect(tokens[1][0]).toEqual value: 'namespace', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.namespace.php', 'keyword.other.namespace.php']
+        expect(tokens[1][1]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.namespace.php']
+        expect(tokens[1][2]).toEqual value: 'Test', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.namespace.php', 'entity.name.type.namespace.php']
+        expect(tokens[1][3]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']


### PR DESCRIPTION
This pull request will fix https://github.com/atom/language-php/issues/29 