### PR TITLE
Don't accept spaces after heredoc beginning identifier. (was: Make Heredoc syntax highlighting work)

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -436,15 +436,8 @@
   'heredoc':
     'patterns': [
       {
-        'begin': '(?=<<<\\s*("?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\1)\\s*$)'
-        'end': '(?!\\G)'
-        'injections':
-          '*':
-            'patterns': [
-              {
-                'include': '#interpolation'
-              }
-            ]
+        'begin': '(?=<<<("?)([a-zA-Z_][a-zA-Z0-9_]*)\\1$)'
+        'end': '(?<=^\\2)'
         'name': 'string.unquoted.heredoc.php'
         'patterns': [
           {
@@ -453,8 +446,8 @@
         ]
       }
       {
-        'begin': '(?=<<<\\s*(\'?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\1)\\s*$)'
-        'end': '(?!\\G)'
+        'begin': '(?=<<<\'([a-zA-Z_]+[a-zA-Z0-9_]*)\'$)'
+        'end': '(?<=^\\1)'
         'name': 'string.unquoted.heredoc.nowdoc.php'
         'patterns': [
           {
@@ -463,223 +456,239 @@
         ]
       }
     ]
-    'repository':
-      'heredoc_interior':
+  'heredoc_interior':
+    'patterns': [
+      {
+        'begin': '(<<<)\\s*([\'"]?)(HTML)(\\2)\\s*$\\n?'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.begin.php'
+          '1':
+            'name': 'punctuation.definition.string.php'
+          '3':
+            'name': 'keyword.operator.heredoc.php'
+        'contentName': 'text.html'
+        'end': '^(\\3)\\b'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.php'
+          '1':
+            'name': 'keyword.operator.heredoc.php'
+        'name': 'meta.embedded.html'
         'patterns': [
           {
-            'begin': '(<<<)\\s*([\'"]?)(HTML)(\\2)\\s*$\\n?'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.begin.php'
-              '1':
-                'name': 'punctuation.definition.string.php'
-              '3':
-                'name': 'keyword.operator.heredoc.php'
-            'contentName': 'text.html'
-            'end': '^(\\3)\\b'
-            'endCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.end.php'
-              '1':
-                'name': 'keyword.operator.heredoc.php'
-            'name': 'meta.embedded.html'
-            'patterns': [
-              {
-                'include': 'text.html.basic'
-              }
-            ]
-          }
-          {
-            'begin': '(<<<)\\s*([\'"]?)(XML)(\\2)\\s*$\\n?'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.begin.php'
-              '1':
-                'name': 'punctuation.definition.string.php'
-              '3':
-                'name': 'keyword.operator.heredoc.php'
-            'contentName': 'text.xml'
-            'end': '^(\\3)\\b'
-            'endCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.end.php'
-              '1':
-                'name': 'keyword.operator.heredoc.php'
-            'name': 'meta.embedded.xml'
-            'patterns': [
-              {
-                'include': 'text.xml'
-              }
-            ]
-          }
-          {
-            'begin': '(<<<)\\s*([\'"]?)(SQL)(\\2)\\s*$\\n?'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.begin.php'
-              '1':
-                'name': 'punctuation.definition.string.php'
-              '3':
-                'name': 'keyword.operator.heredoc.php'
-            'contentName': 'source.sql'
-            'end': '^(\\3)\\b'
-            'endCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.end.php'
-              '1':
-                'name': 'keyword.operator.heredoc.php'
-            'name': 'meta.embedded.sql'
-            'patterns': [
-              {
-                'include': 'source.sql'
-              }
-            ]
-          }
-          {
-            'begin': '(<<<)\\s*([\'"]?)(JAVASCRIPT)(\\2)\\s*$\\n?'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.begin.php'
-              '1':
-                'name': 'punctuation.definition.string.php'
-              '3':
-                'name': 'keyword.operator.heredoc.php'
-            'contentName': 'source.js'
-            'end': '^(\\3)\\b'
-            'endCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.end.php'
-              '1':
-                'name': 'keyword.operator.heredoc.php'
-            'name': 'meta.embedded.js'
-            'patterns': [
-              {
-                'include': 'source.js'
-              }
-            ]
-          }
-          {
-            'begin': '(<<<)\\s*([\'"]?)(JSON)(\\2)\\s*$\\n?'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.begin.php'
-              '1':
-                'name': 'punctuation.definition.string.php'
-              '3':
-                'name': 'keyword.operator.heredoc.php'
-            'contentName': 'source.json'
-            'end': '^(\\3)\\b'
-            'endCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.end.php'
-              '1':
-                'name': 'keyword.operator.heredoc.php'
-            'name': 'meta.embedded.json'
-            'patterns': [
-              {
-                'include': 'source.json'
-              }
-            ]
-          }
-          {
-            'begin': '(<<<)\\s*([\'"]?)(CSS)(\\2)\\s*$\\n?'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.begin.php'
-              '1':
-                'name': 'punctuation.definition.string.php'
-              '3':
-                'name': 'keyword.operator.heredoc.php'
-            'contentName': 'source.css'
-            'end': '^(\\3)\\b'
-            'endCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.end.php'
-              '1':
-                'name': 'keyword.operator.heredoc.php'
-            'name': 'meta.embedded.css'
-            'patterns': [
-              {
-                'include': 'source.css'
-              }
-            ]
-          }
-          {
-            'begin': '(<<<)\\s*([\'"]?)(REGEX)(\\2)\\s*$\\n?'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.begin.php'
-              '1':
-                'name': 'punctuation.definition.string.php'
-              '3':
-                'name': 'keyword.operator.heredoc.php'
-            'contentName': 'string.regexp.heredoc.php'
-            'end': '^(\\3)\\b'
-            'endCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.end.php'
-              '1':
-                'name': 'keyword.operator.heredoc.php'
-            'patterns': [
-              {
-                'comment': 'Escaped from the regexp – there can also be 2 backslashes (since 1 will escape the first)'
-                'match': '(\\\\){1,2}[.$^\\[\\]{}]'
-                'name': 'constant.character.escape.regex.php'
-              }
-              {
-                'captures':
-                  '1':
-                    'name': 'punctuation.definition.arbitrary-repitition.php'
-                  '3':
-                    'name': 'punctuation.definition.arbitrary-repitition.php'
-                'match': '(\\{)\\d+(,\\d+)?(\\})'
-                'name': 'string.regexp.arbitrary-repitition.php'
-              }
-              {
-                'begin': '\\[(?:\\^?\\])?'
-                'captures':
-                  '0':
-                    'name': 'punctuation.definition.character-class.php'
-                'end': '\\]'
-                'name': 'string.regexp.character-class.php'
-                'patterns': [
-                  {
-                    'match': '\\\\[\\\\\'\\[\\]]'
-                    'name': 'constant.character.escape.php'
-                  }
-                ]
-              }
-              {
-                'match': '[$^+*]'
-                'name': 'keyword.operator.regexp.php'
-              }
-              {
-                'begin': '(?<=^|\\s)(#)\\s(?=[[a-zA-Z0-9,. \\t?!-][^\\x{00}-\\x{7F}]]*$)'
-                'beginCaptures':
-                  '1':
-                    'name': 'punctuation.definition.comment.php'
-                'comment': 'We are restrictive in what we allow to go after the comment character to avoid false positives, since the availability of comments depend on regexp flags.'
-                'end': '$\\n?'
-                'endCaptures':
-                  '0':
-                    'name': 'punctuation.definition.comment.php'
-                'name': 'comment.line.number-sign.php'
-              }
-            ]
-          }
-          {
-            'begin': '(<<<)\\s*([\'"]?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\2)'
-            'beginCaptures':
-              '1':
-                'name': 'punctuation.definition.string.php'
-              '3':
-                'name': 'keyword.operator.heredoc.php'
-            'end': '^(\\3)\\b'
-            'endCaptures':
-              '1':
-                'name': 'keyword.operator.heredoc.php'
+            'include': 'text.html.basic'
           }
         ]
+      }
+      {
+        'begin': '(<<<)\\s*([\'"]?)(XML)(\\2)\\s*$\\n?'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.begin.php'
+          '1':
+            'name': 'punctuation.definition.string.php'
+          '3':
+            'name': 'keyword.operator.heredoc.php'
+        'contentName': 'text.xml'
+        'end': '^(\\3)\\b'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.php'
+          '1':
+            'name': 'keyword.operator.heredoc.php'
+        'name': 'meta.embedded.xml'
+        'patterns': [
+          {
+            'include': 'text.xml'
+          }
+        ]
+      }
+      {
+        'begin': '(<<<)\\s*([\'"]?)(SQL)(\\2)\\s*$\\n?'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.begin.php'
+          '1':
+            'name': 'punctuation.definition.string.php'
+          '3':
+            'name': 'keyword.operator.heredoc.php'
+        'contentName': 'source.sql'
+        'end': '^(\\3)\\b'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.php'
+          '1':
+            'name': 'keyword.operator.heredoc.php'
+        'name': 'meta.embedded.sql'
+        'patterns': [
+          {
+            'include': 'source.sql'
+          }
+        ]
+      }
+      {
+        'begin': '(<<<)\\s*([\'"]?)(JAVASCRIPT)(\\2)\\s*$\\n?'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.begin.php'
+          '1':
+            'name': 'punctuation.definition.string.php'
+          '3':
+            'name': 'keyword.operator.heredoc.php'
+        'contentName': 'source.js'
+        'end': '^(\\3)\\b'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.php'
+          '1':
+            'name': 'keyword.operator.heredoc.php'
+        'name': 'meta.embedded.js'
+        'patterns': [
+          {
+            'include': 'source.js'
+          }
+        ]
+      }
+      {
+        'begin': '(<<<)\\s*([\'"]?)(JSON)(\\2)\\s*$\\n?'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.begin.php'
+          '1':
+            'name': 'punctuation.definition.string.php'
+          '3':
+            'name': 'keyword.operator.heredoc.php'
+        'contentName': 'source.json'
+        'end': '^(\\3)\\b'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.php'
+          '1':
+            'name': 'keyword.operator.heredoc.php'
+        'name': 'meta.embedded.json'
+        'patterns': [
+          {
+            'include': 'source.json'
+          }
+        ]
+      }
+      {
+        'begin': '(<<<)\\s*([\'"]?)(CSS)(\\2)\\s*$\\n?'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.begin.php'
+          '1':
+            'name': 'punctuation.definition.string.php'
+          '3':
+            'name': 'keyword.operator.heredoc.php'
+        'contentName': 'source.css'
+        'end': '^(\\3)\\b'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.php'
+          '1':
+            'name': 'keyword.operator.heredoc.php'
+        'name': 'meta.embedded.css'
+        'patterns': [
+          {
+            'include': 'source.css'
+          }
+        ]
+      }
+      {
+        'begin': '(<<<)\\s*([\'"]?)(REGEX)(\\2)\\s*$\\n?'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.begin.php'
+          '1':
+            'name': 'punctuation.definition.string.php'
+          '3':
+            'name': 'keyword.operator.heredoc.php'
+        'contentName': 'string.regexp.heredoc.php'
+        'end': '^(\\3)\\b'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.php'
+          '1':
+            'name': 'keyword.operator.heredoc.php'
+        'patterns': [
+          {
+            'comment': 'Escaped from the regexp – there can also be 2 backslashes (since 1 will escape the first)'
+            'match': '(\\\\){1,2}[.$^\\[\\]{}]'
+            'name': 'constant.character.escape.regex.php'
+          }
+          {
+            'captures':
+              '1':
+                'name': 'punctuation.definition.arbitrary-repitition.php'
+              '3':
+                'name': 'punctuation.definition.arbitrary-repitition.php'
+            'match': '(\\{)\\d+(,\\d+)?(\\})'
+            'name': 'string.regexp.arbitrary-repitition.php'
+          }
+          {
+            'begin': '\\[(?:\\^?\\])?'
+            'captures':
+              '0':
+                'name': 'punctuation.definition.character-class.php'
+            'end': '\\]'
+            'name': 'string.regexp.character-class.php'
+            'patterns': [
+              {
+                'match': '\\\\[\\\\\'\\[\\]]'
+                'name': 'constant.character.escape.php'
+              }
+            ]
+          }
+          {
+            'match': '[$^+*]'
+            'name': 'keyword.operator.regexp.php'
+          }
+          {
+            'begin': '(?<=^|\\s)(#)\\s(?=[[a-zA-Z0-9,. \\t?!-][^\\x{00}-\\x{7F}]]*$)'
+            'beginCaptures':
+              '1':
+                'name': 'punctuation.definition.comment.php'
+            'comment': 'We are restrictive in what we allow to go after the comment character to avoid false positives, since the availability of comments depend on regexp flags.'
+            'end': '$\\n?'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.definition.comment.php'
+            'name': 'comment.line.number-sign.php'
+          }
+        ]
+      }
+      {
+        'begin': '(<<<)("?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\2)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.string.php'
+          '3':
+            'name': 'keyword.operator.heredoc.php'
+        'end': '^(\\3)\\b'
+        'endCaptures':
+          '1':
+            'name': 'keyword.operator.heredoc.php'
+        'patterns': [
+          {
+            'include': '#interpolation'
+          }
+        ]
+      }
+      {
+        'begin': '(<<<)\'([a-zA-Z_]+[a-zA-Z0-9_]*)\''
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.string.php'
+          '2':
+            'name': 'keyword.operator.heredoc.nowdoc.php'
+        'end': '^(\\2)\\b'
+        'endCaptures':
+          '1':
+            'name': 'keyword.operator.heredoc.nowdoc.php'
+      }
+    ]
   'instantiation':
     'begin': '(?i)(new)\\s+'
     'beginCaptures':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -436,7 +436,8 @@
   'heredoc':
     'patterns': [
       {
-        'begin': '(?=<<<\\s*("?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\1)\\s*$)'
+        # [ \\t] was used instead of \\s because \\s will match a newline
+        'begin': '(?=<<<\\s*("?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\1)[ \\t]*$)'
         'end': '(?!\\G)'
         'injections':
           '*':
@@ -453,7 +454,7 @@
         ]
       }
       {
-        'begin': '(?=<<<\\s*\'([a-zA-Z_]+[a-zA-Z0-9_]*)\'\\s*$)'
+        'begin': '(?=<<<\\s*\'([a-zA-Z_]+[a-zA-Z0-9_]*)\'[ \\t]*$)'
         'end': '(?!\\G)'
         'name': 'string.unquoted.heredoc.nowdoc.php'
         'patterns': [
@@ -467,7 +468,7 @@
       'heredoc_interior':
         'patterns': [
           {
-            'begin': '(<<<)\\s*([\'"]?)(HTML)(\\2)(\\s*)$'
+            'begin': '(<<<)\\s*([\'"]?)(HTML)(\\2)([ \\t]*)$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -492,7 +493,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(XML)(\\2)(\\s*)$'
+            'begin': '(<<<)\\s*([\'"]?)(XML)(\\2)([ \\t]*)$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -517,7 +518,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(SQL)(\\2)(\\s*)$'
+            'begin': '(<<<)\\s*([\'"]?)(SQL)(\\2)([ \\t]*)$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -542,7 +543,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(JAVASCRIPT)(\\2)(\\s*)$'
+            'begin': '(<<<)\\s*([\'"]?)(JAVASCRIPT)(\\2)([ \\t]*)$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -567,7 +568,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(JSON)(\\2)(\\s*)$'
+            'begin': '(<<<)\\s*([\'"]?)(JSON)(\\2)([ \\t]*)$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -592,7 +593,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(CSS)(\\2)(\\s*)$'
+            'begin': '(<<<)\\s*([\'"]?)(CSS)(\\2)([ \\t]*)$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -617,7 +618,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(REGEX)(\\2)(\\s*)$'
+            'begin': '(<<<)\\s*([\'"]?)(REGEX)(\\2)([ \\t]*)$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -682,7 +683,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\2)(\\s*)'
+            'begin': '(<<<)\\s*([\'"]?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\2)([ \\t]*)'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.string.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -436,7 +436,7 @@
   'heredoc':
     'patterns': [
       {
-        'begin': '(?=<<<\\s*("?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\1)$)'
+        'begin': '(?=<<<\\s*("?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\1)\\s*$)'
         'end': '(?!\\G)'
         'injections':
           '*':
@@ -453,7 +453,7 @@
         ]
       }
       {
-        'begin': '(?=<<<\\s*\'([a-zA-Z_]+[a-zA-Z0-9_]*)\'$)'
+        'begin': '(?=<<<\\s*\'([a-zA-Z_]+[a-zA-Z0-9_]*)\'\\s*$)'
         'end': '(?!\\G)'
         'name': 'string.unquoted.heredoc.nowdoc.php'
         'patterns': [
@@ -467,7 +467,7 @@
       'heredoc_interior':
         'patterns': [
           {
-            'begin': '(<<<)\\s*([\'"]?)(HTML)(\\2)$'
+            'begin': '(<<<)\\s*([\'"]?)(HTML)(\\2)(\\s*)$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -475,6 +475,8 @@
                 'name': 'punctuation.definition.string.php'
               '3':
                 'name': 'keyword.operator.heredoc.php'
+              '5':
+                'name': 'invalid.illegal.whitespace-in-end-of-line.php'
             'contentName': 'text.html'
             'end': '^(\\3)\\b'
             'endCaptures':
@@ -490,7 +492,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(XML)(\\2)$'
+            'begin': '(<<<)\\s*([\'"]?)(XML)(\\2)(\\s*)$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -498,6 +500,8 @@
                 'name': 'punctuation.definition.string.php'
               '3':
                 'name': 'keyword.operator.heredoc.php'
+              '5':
+                'name': 'invalid.illegal.whitespace-in-end-of-line.php'
             'contentName': 'text.xml'
             'end': '^(\\3)\\b'
             'endCaptures':
@@ -513,7 +517,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(SQL)(\\2)$'
+            'begin': '(<<<)\\s*([\'"]?)(SQL)(\\2)(\\s*)$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -521,6 +525,8 @@
                 'name': 'punctuation.definition.string.php'
               '3':
                 'name': 'keyword.operator.heredoc.php'
+              '5':
+                'name': 'invalid.illegal.whitespace-in-end-of-line.php'
             'contentName': 'source.sql'
             'end': '^(\\3)\\b'
             'endCaptures':
@@ -536,7 +542,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(JAVASCRIPT)(\\2)$'
+            'begin': '(<<<)\\s*([\'"]?)(JAVASCRIPT)(\\2)(\\s*)$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -544,6 +550,8 @@
                 'name': 'punctuation.definition.string.php'
               '3':
                 'name': 'keyword.operator.heredoc.php'
+              '5':
+                'name': 'invalid.illegal.whitespace-in-end-of-line.php'
             'contentName': 'source.js'
             'end': '^(\\3)\\b'
             'endCaptures':
@@ -559,7 +567,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(JSON)(\\2)$'
+            'begin': '(<<<)\\s*([\'"]?)(JSON)(\\2)(\\s*)$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -567,6 +575,8 @@
                 'name': 'punctuation.definition.string.php'
               '3':
                 'name': 'keyword.operator.heredoc.php'
+              '5':
+                'name': 'invalid.illegal.whitespace-in-end-of-line.php'
             'contentName': 'source.json'
             'end': '^(\\3)\\b'
             'endCaptures':
@@ -582,7 +592,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(CSS)(\\2)$'
+            'begin': '(<<<)\\s*([\'"]?)(CSS)(\\2)(\\s*)$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -590,6 +600,8 @@
                 'name': 'punctuation.definition.string.php'
               '3':
                 'name': 'keyword.operator.heredoc.php'
+              '5':
+                'name': 'invalid.illegal.whitespace-in-end-of-line.php'
             'contentName': 'source.css'
             'end': '^(\\3)\\b'
             'endCaptures':
@@ -605,7 +617,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(REGEX)(\\2)$'
+            'begin': '(<<<)\\s*([\'"]?)(REGEX)(\\2)(\\s*)$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -613,6 +625,8 @@
                 'name': 'punctuation.definition.string.php'
               '3':
                 'name': 'keyword.operator.heredoc.php'
+              '5':
+                'name': 'invalid.illegal.whitespace-in-end-of-line.php'
             'contentName': 'string.regexp.heredoc.php'
             'end': '^(\\3)\\b'
             'endCaptures':
@@ -668,12 +682,14 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\2)'
+            'begin': '(<<<)\\s*([\'"]?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\2)(\\s*)'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.string.php'
               '3':
                 'name': 'keyword.operator.heredoc.php'
+              '5':
+                'name': 'invalid.illegal.whitespace-in-end-of-line.php'
             'end': '^(\\3)\\b'
             'endCaptures':
               '1':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -468,7 +468,7 @@
       'heredoc_interior':
         'patterns': [
           {
-            'begin': '(<<<)\\s*([\'"]?)(HTML)(\\2)([ \\t]*)$'
+            'begin': '(<<<)\\s*([\'"]?)(HTML)(\\2)([ \\t]+)?$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -493,7 +493,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(XML)(\\2)([ \\t]*)$'
+            'begin': '(<<<)\\s*([\'"]?)(XML)(\\2)([ \\t]+)?$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -518,7 +518,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(SQL)(\\2)([ \\t]*)$'
+            'begin': '(<<<)\\s*([\'"]?)(SQL)(\\2)([ \\t]+)?$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -543,7 +543,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(JAVASCRIPT)(\\2)([ \\t]*)$'
+            'begin': '(<<<)\\s*([\'"]?)(JAVASCRIPT)(\\2)([ \\t]+)?$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -568,7 +568,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(JSON)(\\2)([ \\t]*)$'
+            'begin': '(<<<)\\s*([\'"]?)(JSON)(\\2)([ \\t]+)?$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -593,7 +593,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(CSS)(\\2)([ \\t]*)$'
+            'begin': '(<<<)\\s*([\'"]?)(CSS)(\\2)([ \\t]+)?$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -618,7 +618,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)(REGEX)(\\2)([ \\t]*)$'
+            'begin': '(<<<)\\s*([\'"]?)(REGEX)(\\2)([ \\t]+)?$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.section.embedded.begin.php'
@@ -683,7 +683,7 @@
             ]
           }
           {
-            'begin': '(<<<)\\s*([\'"]?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\2)([ \\t]*)'
+            'begin': '(<<<)\\s*([\'"]?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\2)([ \\t]+)?'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.string.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -436,8 +436,15 @@
   'heredoc':
     'patterns': [
       {
-        'begin': '(?=<<<("?)([a-zA-Z_][a-zA-Z0-9_]*)\\1$)'
-        'end': '(?<=^\\2)'
+        'begin': '(?=<<<\\s*("?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\1)$)'
+        'end': '(?!\\G)'
+        'injections':
+          '*':
+            'patterns': [
+              {
+                'include': '#interpolation'
+              }
+            ]
         'name': 'string.unquoted.heredoc.php'
         'patterns': [
           {
@@ -446,8 +453,8 @@
         ]
       }
       {
-        'begin': '(?=<<<\'([a-zA-Z_]+[a-zA-Z0-9_]*)\'$)'
-        'end': '(?<=^\\1)'
+        'begin': '(?=<<<\\s*\'([a-zA-Z_]+[a-zA-Z0-9_]*)\'$)'
+        'end': '(?!\\G)'
         'name': 'string.unquoted.heredoc.nowdoc.php'
         'patterns': [
           {
@@ -456,239 +463,223 @@
         ]
       }
     ]
-  'heredoc_interior':
-    'patterns': [
-      {
-        'begin': '(<<<)\\s*([\'"]?)(HTML)(\\2)\\s*$\\n?'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.begin.php'
-          '1':
-            'name': 'punctuation.definition.string.php'
-          '3':
-            'name': 'keyword.operator.heredoc.php'
-        'contentName': 'text.html'
-        'end': '^(\\3)\\b'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.end.php'
-          '1':
-            'name': 'keyword.operator.heredoc.php'
-        'name': 'meta.embedded.html'
+    'repository':
+      'heredoc_interior':
         'patterns': [
           {
-            'include': 'text.html.basic'
-          }
-        ]
-      }
-      {
-        'begin': '(<<<)\\s*([\'"]?)(XML)(\\2)\\s*$\\n?'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.begin.php'
-          '1':
-            'name': 'punctuation.definition.string.php'
-          '3':
-            'name': 'keyword.operator.heredoc.php'
-        'contentName': 'text.xml'
-        'end': '^(\\3)\\b'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.end.php'
-          '1':
-            'name': 'keyword.operator.heredoc.php'
-        'name': 'meta.embedded.xml'
-        'patterns': [
-          {
-            'include': 'text.xml'
-          }
-        ]
-      }
-      {
-        'begin': '(<<<)\\s*([\'"]?)(SQL)(\\2)\\s*$\\n?'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.begin.php'
-          '1':
-            'name': 'punctuation.definition.string.php'
-          '3':
-            'name': 'keyword.operator.heredoc.php'
-        'contentName': 'source.sql'
-        'end': '^(\\3)\\b'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.end.php'
-          '1':
-            'name': 'keyword.operator.heredoc.php'
-        'name': 'meta.embedded.sql'
-        'patterns': [
-          {
-            'include': 'source.sql'
-          }
-        ]
-      }
-      {
-        'begin': '(<<<)\\s*([\'"]?)(JAVASCRIPT)(\\2)\\s*$\\n?'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.begin.php'
-          '1':
-            'name': 'punctuation.definition.string.php'
-          '3':
-            'name': 'keyword.operator.heredoc.php'
-        'contentName': 'source.js'
-        'end': '^(\\3)\\b'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.end.php'
-          '1':
-            'name': 'keyword.operator.heredoc.php'
-        'name': 'meta.embedded.js'
-        'patterns': [
-          {
-            'include': 'source.js'
-          }
-        ]
-      }
-      {
-        'begin': '(<<<)\\s*([\'"]?)(JSON)(\\2)\\s*$\\n?'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.begin.php'
-          '1':
-            'name': 'punctuation.definition.string.php'
-          '3':
-            'name': 'keyword.operator.heredoc.php'
-        'contentName': 'source.json'
-        'end': '^(\\3)\\b'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.end.php'
-          '1':
-            'name': 'keyword.operator.heredoc.php'
-        'name': 'meta.embedded.json'
-        'patterns': [
-          {
-            'include': 'source.json'
-          }
-        ]
-      }
-      {
-        'begin': '(<<<)\\s*([\'"]?)(CSS)(\\2)\\s*$\\n?'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.begin.php'
-          '1':
-            'name': 'punctuation.definition.string.php'
-          '3':
-            'name': 'keyword.operator.heredoc.php'
-        'contentName': 'source.css'
-        'end': '^(\\3)\\b'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.end.php'
-          '1':
-            'name': 'keyword.operator.heredoc.php'
-        'name': 'meta.embedded.css'
-        'patterns': [
-          {
-            'include': 'source.css'
-          }
-        ]
-      }
-      {
-        'begin': '(<<<)\\s*([\'"]?)(REGEX)(\\2)\\s*$\\n?'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.begin.php'
-          '1':
-            'name': 'punctuation.definition.string.php'
-          '3':
-            'name': 'keyword.operator.heredoc.php'
-        'contentName': 'string.regexp.heredoc.php'
-        'end': '^(\\3)\\b'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.end.php'
-          '1':
-            'name': 'keyword.operator.heredoc.php'
-        'patterns': [
-          {
-            'comment': 'Escaped from the regexp – there can also be 2 backslashes (since 1 will escape the first)'
-            'match': '(\\\\){1,2}[.$^\\[\\]{}]'
-            'name': 'constant.character.escape.regex.php'
-          }
-          {
-            'captures':
-              '1':
-                'name': 'punctuation.definition.arbitrary-repitition.php'
-              '3':
-                'name': 'punctuation.definition.arbitrary-repitition.php'
-            'match': '(\\{)\\d+(,\\d+)?(\\})'
-            'name': 'string.regexp.arbitrary-repitition.php'
-          }
-          {
-            'begin': '\\[(?:\\^?\\])?'
-            'captures':
+            'begin': '(<<<)\\s*([\'"]?)(HTML)(\\2)$'
+            'beginCaptures':
               '0':
-                'name': 'punctuation.definition.character-class.php'
-            'end': '\\]'
-            'name': 'string.regexp.character-class.php'
+                'name': 'punctuation.section.embedded.begin.php'
+              '1':
+                'name': 'punctuation.definition.string.php'
+              '3':
+                'name': 'keyword.operator.heredoc.php'
+            'contentName': 'text.html'
+            'end': '^(\\3)\\b'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.end.php'
+              '1':
+                'name': 'keyword.operator.heredoc.php'
+            'name': 'meta.embedded.html'
             'patterns': [
               {
-                'match': '\\\\[\\\\\'\\[\\]]'
-                'name': 'constant.character.escape.php'
+                'include': 'text.html.basic'
               }
             ]
           }
           {
-            'match': '[$^+*]'
-            'name': 'keyword.operator.regexp.php'
-          }
-          {
-            'begin': '(?<=^|\\s)(#)\\s(?=[[a-zA-Z0-9,. \\t?!-][^\\x{00}-\\x{7F}]]*$)'
+            'begin': '(<<<)\\s*([\'"]?)(XML)(\\2)$'
             'beginCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.begin.php'
               '1':
-                'name': 'punctuation.definition.comment.php'
-            'comment': 'We are restrictive in what we allow to go after the comment character to avoid false positives, since the availability of comments depend on regexp flags.'
-            'end': '$\\n?'
+                'name': 'punctuation.definition.string.php'
+              '3':
+                'name': 'keyword.operator.heredoc.php'
+            'contentName': 'text.xml'
+            'end': '^(\\3)\\b'
             'endCaptures':
               '0':
-                'name': 'punctuation.definition.comment.php'
-            'name': 'comment.line.number-sign.php'
+                'name': 'punctuation.section.embedded.end.php'
+              '1':
+                'name': 'keyword.operator.heredoc.php'
+            'name': 'meta.embedded.xml'
+            'patterns': [
+              {
+                'include': 'text.xml'
+              }
+            ]
           }
-        ]
-      }
-      {
-        'begin': '(<<<)("?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\2)'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.definition.string.php'
-          '3':
-            'name': 'keyword.operator.heredoc.php'
-        'end': '^(\\3)\\b'
-        'endCaptures':
-          '1':
-            'name': 'keyword.operator.heredoc.php'
-        'patterns': [
           {
-            'include': '#interpolation'
+            'begin': '(<<<)\\s*([\'"]?)(SQL)(\\2)$'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.begin.php'
+              '1':
+                'name': 'punctuation.definition.string.php'
+              '3':
+                'name': 'keyword.operator.heredoc.php'
+            'contentName': 'source.sql'
+            'end': '^(\\3)\\b'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.end.php'
+              '1':
+                'name': 'keyword.operator.heredoc.php'
+            'name': 'meta.embedded.sql'
+            'patterns': [
+              {
+                'include': 'source.sql'
+              }
+            ]
+          }
+          {
+            'begin': '(<<<)\\s*([\'"]?)(JAVASCRIPT)(\\2)$'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.begin.php'
+              '1':
+                'name': 'punctuation.definition.string.php'
+              '3':
+                'name': 'keyword.operator.heredoc.php'
+            'contentName': 'source.js'
+            'end': '^(\\3)\\b'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.end.php'
+              '1':
+                'name': 'keyword.operator.heredoc.php'
+            'name': 'meta.embedded.js'
+            'patterns': [
+              {
+                'include': 'source.js'
+              }
+            ]
+          }
+          {
+            'begin': '(<<<)\\s*([\'"]?)(JSON)(\\2)$'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.begin.php'
+              '1':
+                'name': 'punctuation.definition.string.php'
+              '3':
+                'name': 'keyword.operator.heredoc.php'
+            'contentName': 'source.json'
+            'end': '^(\\3)\\b'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.end.php'
+              '1':
+                'name': 'keyword.operator.heredoc.php'
+            'name': 'meta.embedded.json'
+            'patterns': [
+              {
+                'include': 'source.json'
+              }
+            ]
+          }
+          {
+            'begin': '(<<<)\\s*([\'"]?)(CSS)(\\2)$'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.begin.php'
+              '1':
+                'name': 'punctuation.definition.string.php'
+              '3':
+                'name': 'keyword.operator.heredoc.php'
+            'contentName': 'source.css'
+            'end': '^(\\3)\\b'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.end.php'
+              '1':
+                'name': 'keyword.operator.heredoc.php'
+            'name': 'meta.embedded.css'
+            'patterns': [
+              {
+                'include': 'source.css'
+              }
+            ]
+          }
+          {
+            'begin': '(<<<)\\s*([\'"]?)(REGEX)(\\2)$'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.begin.php'
+              '1':
+                'name': 'punctuation.definition.string.php'
+              '3':
+                'name': 'keyword.operator.heredoc.php'
+            'contentName': 'string.regexp.heredoc.php'
+            'end': '^(\\3)\\b'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.end.php'
+              '1':
+                'name': 'keyword.operator.heredoc.php'
+            'patterns': [
+              {
+                'comment': 'Escaped from the regexp – there can also be 2 backslashes (since 1 will escape the first)'
+                'match': '(\\\\){1,2}[.$^\\[\\]{}]'
+                'name': 'constant.character.escape.regex.php'
+              }
+              {
+                'captures':
+                  '1':
+                    'name': 'punctuation.definition.arbitrary-repitition.php'
+                  '3':
+                    'name': 'punctuation.definition.arbitrary-repitition.php'
+                'match': '(\\{)\\d+(,\\d+)?(\\})'
+                'name': 'string.regexp.arbitrary-repitition.php'
+              }
+              {
+                'begin': '\\[(?:\\^?\\])?'
+                'captures':
+                  '0':
+                    'name': 'punctuation.definition.character-class.php'
+                'end': '\\]'
+                'name': 'string.regexp.character-class.php'
+                'patterns': [
+                  {
+                    'match': '\\\\[\\\\\'\\[\\]]'
+                    'name': 'constant.character.escape.php'
+                  }
+                ]
+              }
+              {
+                'match': '[$^+*]'
+                'name': 'keyword.operator.regexp.php'
+              }
+              {
+                'begin': '(?<=^|\\s)(#)\\s(?=[[a-zA-Z0-9,. \\t?!-][^\\x{00}-\\x{7F}]]*$)'
+                'beginCaptures':
+                  '1':
+                    'name': 'punctuation.definition.comment.php'
+                'comment': 'We are restrictive in what we allow to go after the comment character to avoid false positives, since the availability of comments depend on regexp flags.'
+                'end': '$\\n?'
+                'endCaptures':
+                  '0':
+                    'name': 'punctuation.definition.comment.php'
+                'name': 'comment.line.number-sign.php'
+              }
+            ]
+          }
+          {
+            'begin': '(<<<)\\s*([\'"]?)([a-zA-Z_]+[a-zA-Z0-9_]*)(\\2)'
+            'beginCaptures':
+              '1':
+                'name': 'punctuation.definition.string.php'
+              '3':
+                'name': 'keyword.operator.heredoc.php'
+            'end': '^(\\3)\\b'
+            'endCaptures':
+              '1':
+                'name': 'keyword.operator.heredoc.php'
           }
         ]
-      }
-      {
-        'begin': '(<<<)\'([a-zA-Z_]+[a-zA-Z0-9_]*)\''
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.definition.string.php'
-          '2':
-            'name': 'keyword.operator.heredoc.nowdoc.php'
-        'end': '^(\\2)\\b'
-        'endCaptures':
-          '1':
-            'name': 'keyword.operator.heredoc.nowdoc.php'
-      }
-    ]
   'instantiation':
     'begin': '(?i)(new)\\s+'
     'beginCaptures':

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -437,3 +437,151 @@ describe 'PHP grammar', ->
         expect(tokens[1][9]).toEqual value: '{', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.section.scope.begin.php']
         expect(tokens[1][10]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.section.scope.end.php']
         expect(tokens[1][11]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
+
+      it 'should tokenize a simple heredoc correctly', ->
+        tokens = grammar.tokenizeLines """<?php
+        $a = <<<HEREDOC
+        I am a heredoc
+        HEREDOC;"""
+
+        expect(tokens[1][0]).toEqual value: '$', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[1][1]).toEqual value: 'a', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php']
+        expect(tokens[1][2]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+        expect(tokens[1][3]).toEqual value: '=', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.assignment.php']
+        expect(tokens[1][4]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+        expect(tokens[1][5]).toEqual value: '<<<', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'punctuation.definition.string.php']
+        expect(tokens[1][6]).toEqual value: 'HEREDOC', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+        expect(tokens[2][0]).toEqual value: 'I am a heredoc', scopes ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[3][0]).toEqual value: 'HEREDOC', scopes ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+        expect(tokens[3][1]).toEqual value: ';', scopes ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
+
+      it 'should tokenize a longer heredoc correctly', ->
+        tokens = grammar.tokenizeLines """<?php
+        $a = <<<GITHUB
+        This is a plain string.
+        SELECT * FROM github WHERE octocat = 'awesome' and ID = 1;
+        <strong>rainbows</strong>
+
+        if(awesome) {
+            doSomething(10, function(x){
+              console.log(x*x);
+            });
+        }
+        GITHUB;"""
+
+        expect(tokens[1][0]).toEqual value: '$', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[1][1]).toEqual value: 'a', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php']
+        expect(tokens[1][2]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+        expect(tokens[1][3]).toEqual value: '=', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.assignment.php']
+        expect(tokens[1][4]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+        expect(tokens[1][5]).toEqual value: '<<<', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'punctuation.definition.string.php']
+        expect(tokens[1][6]).toEqual value: 'GITHUB', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+        expect(tokens[2][0]).toEqual value: 'This is a plain string.', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[3][0]).toEqual value: 'SELECT * FROM github WHERE octocat = \'awesome\' and ID = 1;', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[4][0]).toEqual value: '<strong>rainbows</strong>', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[5][0]).toEqual value: '', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[6][0]).toEqual value: 'if(awesome) {', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[7][0]).toEqual value: '    doSomething(10, function(x){', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[8][0]).toEqual value: '      console.log(x*x);', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[9][0]).toEqual value: '    });', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[10][0]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[11][0]).toEqual value: 'GITHUB', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+        expect(tokens[11][1]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
+
+      it 'should tokenize a longer heredoc with interpolated values and escaped characters correctly', ->
+        tokens = grammar.tokenizeLines """<?php
+        $a = <<<GITHUB
+        This is a plain string.
+        Jumpin' Juniper is \\"The $thing\\"
+        SELECT * FROM github WHERE octocat = 'awesome' and ID = 1;
+        <strong>rainbows</strong>
+
+        if(awesome) {
+            doSomething(10, function(x){
+              console.log(x*x);
+            });
+        }
+        GITHUB;"""
+
+        expect(tokens[1][0]).toEqual value: '$', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[1][1]).toEqual value: 'a', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php']
+        expect(tokens[1][2]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+        expect(tokens[1][3]).toEqual value: '=', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.assignment.php']
+        expect(tokens[1][4]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+        expect(tokens[1][5]).toEqual value: '<<<', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'punctuation.definition.string.php']
+        expect(tokens[1][6]).toEqual value: 'GITHUB', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+        expect(tokens[2][0]).toEqual value: 'This is a plain string.', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[3][0]).toEqual value: 'Jumpin\' Juniper is ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[3][1]).toEqual value: '\\"', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'constant.character.escape.php']
+        expect(tokens[3][2]).toEqual value: 'The ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[3][3]).toEqual value: '$', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[3][4]).toEqual value: 'thing', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'variable.other.php']
+        expect(tokens[3][5]).toEqual value: '\\"', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'constant.character.escape.php']
+        expect(tokens[4][0]).toEqual value: 'SELECT * FROM github WHERE octocat = \'awesome\' and ID = 1;', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[5][0]).toEqual value: '<strong>rainbows</strong>', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[6][0]).toEqual value: '', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[7][0]).toEqual value: 'if(awesome) {', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[8][0]).toEqual value: '    doSomething(10, function(x){', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[9][0]).toEqual value: '      console.log(x*x);', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[10][0]).toEqual value: '    });', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[11][0]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[12][0]).toEqual value: 'GITHUB', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+        expect(tokens[12][1]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
+
+      it 'should tokenize a nowdoc with interpolated values correctly', ->
+        tokens = grammar.tokenizeLines """<?php
+        $a = <<<'GITHUB'
+        This is a plain string.
+        Jumpin' Juniper is \\"The $thing\\"
+        SELECT * FROM github WHERE octocat = 'awesome' and ID = 1;
+        <strong>rainbows</strong>
+
+        if(awesome) {
+            doSomething(10, function(x){
+              console.log(x*x);
+            });
+        }
+        GITHUB;"""
+
+        expect(tokens[1][0]).toEqual value: '$', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[1][1]).toEqual value: 'a', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php']
+        expect(tokens[1][2]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+        expect(tokens[1][3]).toEqual value: '=', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.assignment.php']
+        expect(tokens[1][4]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+        expect(tokens[1][5]).toEqual value: '<<<', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'punctuation.definition.string.php']
+        expect(tokens[1][6]).toEqual value: 'GITHUB', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+        expect(tokens[2][0]).toEqual value: 'This is a plain string.', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[3][0]).toEqual value: 'Jumpin\' Juniper is "The $thing"', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[4][0]).toEqual value: 'SELECT * FROM github WHERE octocat = \'awesome\' and ID = 1;', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[5][0]).toEqual value: '<strong>rainbows</strong>', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[6][0]).toEqual value: '', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[7][0]).toEqual value: 'if(awesome) {', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[8][0]).toEqual value: '    doSomething(10, function(x){', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[9][0]).toEqual value: '      console.log(x*x);', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[10][0]).toEqual value: '    });', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[11][0]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+        expect(tokens[12][0]).toEqual value: 'GITHUB', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+        expect(tokens[12][1]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
+
+      it 'should tokenize a heredoc with embedded HTML correctly', ->
+        tokens = grammar.tokenizeLines """<?php
+        $a = <<<HTML
+        <strong>rainbows</strong>
+        HTML;"""
+
+        expect(tokens[1][0]).toEqual value: '$', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[1][1]).toEqual value: 'a', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php']
+        expect(tokens[1][2]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+        expect(tokens[1][3]).toEqual value: '=', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.assignment.php']
+        expect(tokens[1][4]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+        expect(tokens[1][5]).toEqual value: '<<<', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'punctuation.definition.string.php']
+        expect(tokens[1][6]).toEqual value: 'HTML', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+        expect(tokens[2][0]).toEqual value: '<', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'text.html.basic', 'meta.tag.inline.any.html', 'punctuation.definition.tag.begin.html']
+        expect(tokens[2][1]).toEqual value: 'strong', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'text.html.basic', 'meta.tag.inline.any.html', 'entity.name.tag.inline.any.html']
+        expect(tokens[2][2]).toEqual value: '>', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'text.html.basic', 'meta.tag.inline.any.html', 'punctuation.definition.tag.end.html']
+        expect(tokens[2][3]).toEqual value: 'rainbows', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'text.html.basic']
+        expect(tokens[2][4]).toEqual value: '</', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'text.html.basic', 'meta.tag.inline.any.html', 'punctuation.definition.tag.begin.html']
+        expect(tokens[2][5]).toEqual value: 'strong', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'text.html.basic', 'meta.tag.inline.any.html', 'entity.name.tag.inline.any.html']
+        expect(tokens[2][6]).toEqual value: '>', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'text.html.basic', 'meta.tag.inline.any.html', 'punctuation.definition.tag.end.html']
+        expect(tokens[3][0]).toEqual value: 'HTML', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+        expect(tokens[3][1]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']


### PR DESCRIPTION
I've modified some of the regular expressions so that Heredoc syntax highlighting now works.

Also, I've disabled the "internal heredocs" because, as far as I know, there is no such thing in PHP.
