### PR TITLE
Added syntax support for PHPDoc api tag

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1367,7 +1367,7 @@
         'match': '(@xlink)\\s+(.+)\\s*$'
       }
       {
-        'match': '\\@(a(bstract|uthor)|c(ategory|opyright)|example|global|internal|li(cense|nk)|pa(ckage|ram)|return|s(ee|ince|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|final|ignore)\\b'
+        'match': '\\@(a(pi|bstract|uthor)|c(ategory|opyright)|example|global|internal|li(cense|nk)|pa(ckage|ram)|return|s(ee|ince|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|final|ignore)\\b'
         'name': 'keyword.other.phpdoc.php'
       }
       {

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -254,3 +254,11 @@ describe 'PHP grammar', ->
         expect(tokens[1][14]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
         expect(tokens[1][15]).toEqual value: '{', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.section.scope.begin.php']
         expect(tokens[1][16]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.section.scope.end.php']
+
+      it 'should tokenize @api tag correctly', ->
+        tokens = grammar.tokenizeLines "<?php\n/**\n*@api\n*/"
+
+        expect(tokens[1][0]).toEqual value: '/**', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'punctuation.definition.comment.php']
+        expect(tokens[2][0]).toEqual value: '*', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php']
+        expect(tokens[2][1]).toEqual value: '@api', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[3][0]).toEqual value: '*/', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'punctuation.definition.comment.php']


### PR DESCRIPTION
Added syntax support for `@api` 

See http://phpdoc.org/docs/latest/references/phpdoc/tags/api.html or https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md#81-api