### PR TITLE
Include ] at end of line in outdent pattern

### DIFF
--- a/settings/language-php.cson
+++ b/settings/language-php.cson
@@ -3091,7 +3091,7 @@
 '.source.php:not(.string)':
   'editor':
     'increaseIndentPattern': '(?x)\n\t    (   \\{ (?! .+ \\} ) .*\n\t    |   array\\(\n\t    |   (\\[)\n\t    |   ((else)?if|else|for(each)?|while|switch) .* :\n\t    )   \\s* (/[/*] .*)? $'
-    'decreaseIndentPattern': '(?x)\n\t    ^ (.* \\*/)? \\s*\n\t    (\n\t        (\\})         |\n\t        (\\)+[;,])    |\n\t        (\\][;,])     |\n\t        (else:)      |\n\t        ((end(if|for(each)?|while|switch));)\n\t    )\n\t'
+    'decreaseIndentPattern': '(?x)\n\t    ^ (.* \\*/)? \\s*\n\t    (\n\t        (\\})         |\n\t        (\\)+[;,])    |\n\t        (\\]([;,]|$))     |\n\t        (else:)      |\n\t        ((end(if|for(each)?|while|switch));)\n\t    )\n\t'
 '.text.html.php':
   'editor':
     'nonWordCharacters': '/\\()"\':,.;<>~!@#%^&*|+=[]{}`?-'

--- a/settings/language-php.cson
+++ b/settings/language-php.cson
@@ -3091,7 +3091,7 @@
 '.source.php:not(.string)':
   'editor':
     'increaseIndentPattern': '(?x)\n\t    (   \\{ (?! .+ \\} ) .*\n\t    |   array\\(\n\t    |   (\\[)\n\t    |   ((else)?if|else|for(each)?|while|switch) .* :\n\t    )   \\s* (/[/*] .*)? $'
-    'decreaseIndentPattern': '(?x)\n\t    ^ (.* \\*/)? \\s*\n\t    (\n\t        (\\})         |\n\t        (\\)+[;,])    |\n\t        (\\]([;,]|$))     |\n\t        (else:)      |\n\t        ((end(if|for(each)?|while|switch));)\n\t    )\n\t'
+    'decreaseIndentPattern': '(?x)\n\t    ^ (.* \\*/)? \\s*\n\t    (\n\t        (\\})         |\n\t        (\\)+[;,])    |\n\t        (\\]\\)*([;,]|$))     |\n\t        (else:)      |\n\t        ((end(if|for(each)?|while|switch));)\n\t    )\n\t'
 '.text.html.php':
   'editor':
     'nonWordCharacters': '/\\()"\':,.;<>~!@#%^&*|+=[]{}`?-'


### PR DESCRIPTION
Refs #63 

Previously, a `]` needed to be followed by a `,` or a `;` to trigger an outdent. I've now included plain `]` at the end of the line in the pattern by changing the pattern from `\][,;]` to `\]([,;]]|$)`.

These multi-line indent/outdent regexes were converted from the TextMate bundle and look horrific, but I just left them this way and made a small edit.

It would be great if someone could test out this branch for a while and make sure there's no unintended consequences. I'm not experienced in PHP at all.

/cc @JesseLeite @crantok