### PR TITLE
Fix assignment operator consuming comparison operators

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1189,8 +1189,16 @@
         'name': 'keyword.operator.error-control.php'
       }
       {
+        'match': '(===|==|!==|!=|<>)'
+        'name': 'keyword.operator.comparison.php'
+      }
+      {
         'match': '=|\\+=|\\-=|\\*=|/=|%=|&=|\\|=|\\^=|<<=|>>='
         'name': 'keyword.operator.assignment.php'
+      }
+      {
+        'match': '(<=|>=|<|>)'
+        'name': 'keyword.operator.comparison.php'
       }
       {
         'match': '(\\-\\-|\\+\\+)'
@@ -1210,10 +1218,6 @@
       {
         'match': '<<|>>|~|\\^|&|\\|'
         'name': 'keyword.operator.bitwise.php'
-      }
-      {
-        'match': '(===|==|!==|!=|<=|>=|<>|<|>)'
-        'name': 'keyword.operator.comparison.php'
       }
       {
         'begin': '(?i)\\b(instanceof)\\b\\s+(?=[\\\\$a-z_])'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -74,6 +74,17 @@ describe 'PHP grammar', ->
       expect(tokens[1][5]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
 
     describe 'combined operators', ->
+      it 'should tokenize === correctly', ->
+        tokens = grammar.tokenizeLines "<?php\n$test === 2;"
+
+        expect(tokens[1][0]).toEqual value: '$', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[1][1]).toEqual value: 'test', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php']
+        expect(tokens[1][2]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+        expect(tokens[1][3]).toEqual value: '===', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.comparison.php']
+        expect(tokens[1][4]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+        expect(tokens[1][5]).toEqual value: '2', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'constant.numeric.php']
+        expect(tokens[1][6]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
+
       it 'should tokenize += correctly', ->
         tokens = grammar.tokenizeLines "<?php\n$test += 2;"
 


### PR DESCRIPTION
`===` is currently being treated as three assignment operators.