### PR TITLE
update constant.character.escape.php

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1504,9 +1504,7 @@
     'name': 'string.regexp.single-quoted.php'
     'patterns': [
       {
-        'comment': 'Support both PHP string and regex escaping'
-        'match': '(?x) \\\\ (?: \\\\ (?: \\\\ [\\\\\']? | [^\'] ) | . )'
-        'name': 'constant.character.escape.php'
+       'include': '#single_quote_regex_escape'
       }
       {
         'captures':
@@ -1524,25 +1522,16 @@
             'name': 'punctuation.definition.character-class.php'
         'end': '\\]'
         'name': 'string.regexp.character-class.php'
-        # 'patterns': [
-        #   {
-        #     # 'include': '#single_quote_regex_escape'
-        #   }
-        # ]
       }
       {
         'match': '[$^+*]'
         'name': 'keyword.operator.regexp.php'
       }
-      # {
-      #   'include': '#single_quote_regex_escape'
-      # }
     ]
-    # 'repository':
-    #   'single_quote_regex_escape':
-    #     'comment': 'Support both PHP string and regex escaping'
-    #     'match': '(?x) \\\\ (?: \\\\ (?: \\\\ [\\\\\']? | [^\'] ) | . )'
-    #     'name': 'constant.character.escape.php'
+  'single_quote_regex_escape':
+    'comment': 'Support both PHP string and regex escaping'
+    'match': '(?x) \\\\ (?: \\\\ (?: \\\\ [\\\\\']? | [^\'] ) | . )'
+    'name': 'constant.character.escape.php'
   'sql-string-double-quoted':
     'begin': '"\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER)\\b)'
     'beginCaptures':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1504,6 +1504,11 @@
     'name': 'string.regexp.single-quoted.php'
     'patterns': [
       {
+        'comment': 'Support both PHP string and regex escaping'
+        'match': '(?x) \\\\ (?: \\\\ (?: \\\\ [\\\\\']? | [^\'] ) | . )'
+        'name': 'constant.character.escape.php'
+      }
+      {
         'captures':
           '1':
             'name': 'punctuation.definition.arbitrary-repetition.php'
@@ -1519,25 +1524,25 @@
             'name': 'punctuation.definition.character-class.php'
         'end': '\\]'
         'name': 'string.regexp.character-class.php'
-        'patterns': [
-          {
-            'include': '#single_quote_regex_escape'
-          }
-        ]
+        # 'patterns': [
+        #   {
+        #     # 'include': '#single_quote_regex_escape'
+        #   }
+        # ]
       }
       {
         'match': '[$^+*]'
         'name': 'keyword.operator.regexp.php'
       }
-      {
-        'include': '#single_quote_regex_escape'
-      }
+      # {
+      #   'include': '#single_quote_regex_escape'
+      # }
     ]
-    'repository':
-      'single_quote_regex_escape':
-        'comment': 'Support both PHP string and regex escaping'
-        'match': '(?x) \\\\ (?: \\\\ (?: \\\\ [\\\\\']? | [^\'] ) | . )'
-        'name': 'constant.character.escape.php'
+    # 'repository':
+    #   'single_quote_regex_escape':
+    #     'comment': 'Support both PHP string and regex escaping'
+    #     'match': '(?x) \\\\ (?: \\\\ (?: \\\\ [\\\\\']? | [^\'] ) | . )'
+    #     'name': 'constant.character.escape.php'
   'sql-string-double-quoted':
     'begin': '"\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER)\\b)'
     'beginCaptures':

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -455,6 +455,13 @@ describe 'PHP grammar', ->
         expect(tokens[1][4]).toEqual value: '/\'', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.regexp.single-quoted.php', 'punctuation.definition.string.end.php']
         expect(tokens[1][5]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
 
+      it 'should tokenize single quoted string regex with escaped bracket', ->
+        tokens = grammar.tokenizeLines "<?php\n'/\[/'"
+
+        expect(tokens[1][0]).toEqual value: '\'/', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.regexp.single-quoted.php', 'punctuation.definition.string.begin.php']
+        expect(tokens[1][1]).toEqual value: '\[', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.regexp.single-quoted.php', 'constant.character.escape.php']
+        expect(tokens[1][2]).toEqual value: '/\'', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.regexp.single-quoted.php', 'punctuation.definition.string.end.php']
+
       it 'should tokenize opening scope of a closure correctly', ->
         tokens = grammar.tokenizeLines "<?php\n$a = function() {};"
 

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -456,10 +456,10 @@ describe 'PHP grammar', ->
         expect(tokens[1][5]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
 
       it 'should tokenize single quoted string regex with escaped bracket', ->
-        tokens = grammar.tokenizeLines "<?php\n'/\[/'"
+        tokens = grammar.tokenizeLines "<?php\n'/\\[/'"
 
         expect(tokens[1][0]).toEqual value: '\'/', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.regexp.single-quoted.php', 'punctuation.definition.string.begin.php']
-        expect(tokens[1][1]).toEqual value: '\[', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.regexp.single-quoted.php', 'constant.character.escape.php']
+        expect(tokens[1][1]).toEqual value: '\\[', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.regexp.single-quoted.php', 'constant.character.escape.php']
         expect(tokens[1][2]).toEqual value: '/\'', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.regexp.single-quoted.php', 'punctuation.definition.string.end.php']
 
       it 'should tokenize opening scope of a closure correctly', ->


### PR DESCRIPTION
Fixes #124: Update regex-single-quoted to place the constant.character.escape.php inside the patterns array so as to fix the broken regex highlighting in single quoted php regular expressions. My screenshots and description are attached to the issue. Please let me know if I need to update, or alter this PR if it is not aligned properly with the Contribution Guidelines. 