### PR TITLE
indent all lines between parentheses

### DIFF
--- a/settings/language-php.cson
+++ b/settings/language-php.cson
@@ -3340,8 +3340,8 @@
     'decreaseIndentPattern': '(?x)\n\t    ^ (.* \\*/)? \\s*\n\t    (\\)+)\n\t'
 '.source.php:not(.string)':
   'editor':
-    'increaseIndentPattern': '(?x)\n\t    (   \\{ (?! .+ \\} ) .*\n\t    |   array\\(\n\t    |   (\\[)\n\t    |   ((else)?if|else|for(each)?|while|switch) .* :\n\t    )   \\s* (/[/*] .*)? $'
-    'decreaseIndentPattern': '(?x)\n\t    ^ (.* \\*/)? \\s*\n\t    (\n\t        (\\})         |\n\t        (\\)+[;,])    |\n\t        (\\]\\)*([;,]|$))     |\n\t        (else:)      |\n\t        ((end(if|for(each)?|while|switch));)\n\t    )\n\t'
+    'increaseIndentPattern': '(?x)\n\t    (   \\{ (?! .+ \\} ) .*\n\t    |   \\(\n\t    |   (\\[)\n\t    |   ((else)?if|else|for(each)?|while|switch) .* :\n\t    )   \\s* (/[/*] .*)? $'
+    'decreaseIndentPattern': '(?x)\n\t    ^ (.* \\*/)? \\s*\n\t    (\n\t        (\\})         |\n\t        (\\)+([;,]|\\s*\\{))    |\n\t        (\\]\\)*([;,]|$))     |\n\t        (else:)      |\n\t        ((end(if|for(each)?|while|switch));)\n\t    )\n\t'
 '.text.html.php':
   'editor':
     'nonWordCharacters': '/\\()"\':,.;<>~!@#%^&*|+=[]{}`?-'


### PR DESCRIPTION
Refs #63 

1. A `(` did not trigger an indent except for `array(`
2. A `) {` did not trigger an outdent