### PR TITLE
Fix doc_f snippet's return type selection

### DIFF
--- a/snippets/language-php.cson
+++ b/snippets/language-php.cson
@@ -144,4 +144,4 @@
     'body': 'var_dump($1);$0'
   'PHPDoc function …':
     'prefix': 'doc_f'
-    'body': '/**\n * ${6:undocumented function summary}\n *\n * ${7:Undocumented function long description}\n *\n * @param ${8:type} ${9:var} ${10:Description}\n * @return {11:return type}\n */\n${1:public }function ${2:FunctionName}(${3:$${4:value}${5:=\'\'}})\n{\n\t${0:# code...}\n}'
+    'body': '/**\n * ${6:undocumented function summary}\n *\n * ${7:Undocumented function long description}\n *\n * @param ${8:type} ${9:var} ${10:Description}\n * @return ${11:return type}\n */\n${1:public }function ${2:FunctionName}(${3:$${4:value}${5:=\'\'}})\n{\n\t${0:# code...}\n}'


### PR DESCRIPTION
Fixes this:

![doc_f](https://cloud.githubusercontent.com/assets/1017132/16416011/ce77cd88-3d48-11e6-8cc6-94d56b32b66b.png)
