### PR TITLE
Move doc_f snippet to appropriate scope

### DIFF
--- a/snippets/language-php.cson
+++ b/snippets/language-php.cson
@@ -14,6 +14,9 @@
   'Class Variable':
     'prefix': 'doc_v'
     'body': '/**\n * ${3:undocumented class variable}\n *\n * @var ${4:string}\n */\n${1:var} $$2;$0'
+  'PHPDoc function …':
+    'prefix': 'doc_f'
+    'body': '/**\n * ${6:undocumented function summary}\n *\n * ${7:Undocumented function long description}\n *\n * @param ${8:type} ${9:var} ${10:Description}\n * @return ${11:return type}\n */\n${1:public }function ${2:FunctionName}(${3:$${4:value}${5:=\'\'}})\n{\n\t${0:# code...}\n}'
   'Start Docblock':
     'prefix': '/**'
     'body': '/**\n * $0\n */'
@@ -142,6 +145,3 @@
   '<?php if (…) ?> … <?php endif ?>':
     'prefix': 'if'
     'body': '<?php if (${1:condition}): ?>\n\t$0\n<?php endif; ?>'
-  'PHPDoc function …':
-    'prefix': 'doc_f'
-    'body': '/**\n * ${6:undocumented function summary}\n *\n * ${7:Undocumented function long description}\n *\n * @param ${8:type} ${9:var} ${10:Description}\n * @return ${11:return type}\n */\n${1:public }function ${2:FunctionName}(${3:$${4:value}${5:=\'\'}})\n{\n\t${0:# code...}\n}'


### PR DESCRIPTION
The reason for this is exactly the same as for #146. Now all snippets should be fine in terms of their intended scope.