### PR TITLE
Add firstLineMatch support for hashbangs/modelines

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -15,7 +15,25 @@
   'phtml'
   'profile'
 ]
-'firstLineMatch': '^#!.*(?<!-)php[0-9]{0,1}\\b'
+'firstLineMatch': '''(?x)
+  # Hashbang
+  ^\\#!.*(?:\\s|\\/)
+    php\\d?
+  (?:$|\\s)
+  |
+  # Modeline
+  (?i:
+    # Emacs
+    -\\*-(?:\\s*(?=[^:;\\s]+\\s*-\\*-)|(?:.*?[;\\s]|(?<=-\\*-))mode\\s*:\\s*)
+      php
+    (?=[\\s;]|(?<![-*])-\\*-).*?-\\*-
+    |
+    # Vim
+    (?:(?:\\s|^)vi(?:m[<=>]?\\d+|m)?|\\sex)(?=:(?=\\s*set?\\s[^\\n:]+:)|:(?!\\s*set?\\s))(?:(?:\\s|\\s*:\\s*)\\w*(?:\\s*=(?:[^\\n\\\\\\s]|\\\\.)*)?)*[\\s:](?:filetype|ft|syntax)\\s*=
+      (?:php|phtml)
+    (?=\\s|:|$)
+  )
+'''
 'foldingStartMarker': '(/\\*|\\{\\s*$|<<<HTML)'
 'foldingStopMarker': '(\\*/|^\\s*\\}|^HTML;)'
 'injections':

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -487,3 +487,117 @@ describe 'PHP grammar', ->
         expect(tokens[1][3]).toEqual value: 'test', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.single.php', 'meta.string-contents.quoted.single.php']
         expect(tokens[1][4]).toEqual value: '\'', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
         expect(tokens[1][5]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
+
+  describe 'firstLineMatch', ->
+    it "recognises interpreter directives", ->
+      valid = """
+        #!/usr/bin/php
+        #!/usr/bin/php foo=bar/
+        #!/usr/sbin/php5
+        #!/usr/sbin/php7 foo bar baz
+        #!/usr/bin/php perl
+        #!/usr/bin/php4 bin/perl
+        #!/usr/bin/env php
+        #!/bin/php
+        #!/usr/bin/php --script=usr/bin
+        #! /usr/bin/env A=003 B=149 C=150 D=xzd E=base64 F=tar G=gz H=head I=tail php
+        #!\t/usr/bin/env --foo=bar php --quu=quux
+        #! /usr/bin/php
+        #!/usr/bin/env php
+      """
+      for line in valid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).not.toBeNull()
+
+      invalid = """
+        \x20#!/usr/sbin/php
+        \t#!/usr/sbin/php
+        #!/usr/bin/env-php/node-env/
+        #!/usr/bin/env-php
+        #! /usr/binphp
+        #!/usr/bin.php
+        #!\t/usr/bin/env --php=bar
+      """
+      for line in invalid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()
+
+    it "recognises Emacs modelines", ->
+      valid = """
+        #-*- PHP -*-
+        #-*- mode: PHP -*-
+        /* -*-php-*- */
+        // -*- PHP -*-
+        /* -*- mode:PHP -*- */
+        // -*- font:bar;mode:pHp -*-
+        // -*- font:bar;mode:PHP;foo:bar; -*-
+        // -*-font:mode;mode:php-*-
+        // -*- foo:bar mode: php bar:baz -*-
+        " -*-foo:bar;mode:php;bar:foo-*- ";
+        " -*-font-mode:foo;mode:php;foo-bar:quux-*-"
+        "-*-font:x;foo:bar; mode : PHP; bar:foo;foooooo:baaaaar;fo:ba;-*-";
+        "-*- font:x;foo : bar ; mode : php ; bar : foo ; foooooo:baaaaar;fo:ba-*-";
+      """
+      for line in valid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).not.toBeNull()
+
+      invalid = """
+        /* --*php-*- */
+        /* -*-- php -*-
+        /* -*- -- PHP -*-
+        /* -*- PHP -;- -*-
+        // -*- PHPetrol -*-
+        // -*- PHP; -*-
+        // -*- php-stuff -*-
+        /* -*- model:php -*-
+        /* -*- indent-mode:php -*-
+        // -*- font:mode;php -*-
+        // -*- mode: -*- php
+        // -*- mode: stop-using-php -*-
+        // -*-font:mode;mode:php--*-
+      """
+      for line in invalid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()
+
+    it "recognises Vim modelines", ->
+      valid = """
+        vim: se filetype=php:
+        # vim: se ft=php:
+        # vim: set ft=PHP:
+        # vim: set filetype=PHP:
+        # vim: ft=PHTML
+        # vim: syntax=phtml
+        # vim: se syntax=php:
+        # ex: syntax=PHP
+        # vim:ft=php
+        # vim600: ft=php
+        # vim>600: set ft=PHP:
+        # vi:noai:sw=3 ts=6 ft=phtml
+        # vi::::::::::noai:::::::::::: ft=phtml
+        # vim:ts=4:sts=4:sw=4:noexpandtab:ft=phtml
+        # vi:: noai : : : : sw   =3 ts   =6 ft  =php
+        # vim: ts=4: pi sts=4: ft=php: noexpandtab: sw=4:
+        # vim: ts=4 sts=4: ft=php noexpandtab:
+        # vim:noexpandtab sts=4 ft=php ts=4
+        # vim:noexpandtab:ft=php
+        # vim:ts=4:sts=4 ft=phtml:noexpandtab:\x20
+        # vim:noexpandtab titlestring=hi\|there\\\\ ft=phtml ts=4
+      """
+      for line in valid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).not.toBeNull()
+
+      invalid = """
+        ex: se filetype=php:
+        _vi: se filetype=php:
+         vi: se filetype=php
+        # vim set ft=phpetrol
+        # vim: soft=php
+        # vim: clean-syntax=php:
+        # vim set ft=php:
+        # vim: setft=php:
+        # vim: se ft=php backupdir=tmp
+        # vim: set ft=php set cmdheight=1
+        # vim:noexpandtab sts:4 ft:php ts:4
+        # vim:noexpandtab titlestring=hi\\|there\\ ft=php ts=4
+        # vim:noexpandtab titlestring=hi\\|there\\\\\\ ft=php ts=4
+      """
+      for line in invalid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()


### PR DESCRIPTION
Aside from adding support for Emacs and Vim-style modelines, this PR also fixes a bug with matching interpreter directives, where `#!/usr/local/php/bin` or `#!/bin/$php` would also be matched incorrectly.