### PR TITLE
Add Shorthand echo

### DIFF
--- a/snippets/language-php.cson
+++ b/snippets/language-php.cson
@@ -5,6 +5,9 @@
   '<?php … ?>':
     'prefix': 'php'
     'body': 'php $0 ?>'
+  'shorthand echo':
+    'prefix': '<?'
+    'body': '<?= $0 ?>'  
   'function __construct':
     'prefix': 'con'
     'body': '${1:public }function __construct(${2:${3:Type }$${4:foo} ${5:= ${6:null}}})\n{\n\t${2:$this->${4:foo} = $${4:foo};}$0\n}'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Added php shorthand echo snippet

### Alternate Designs

I do not see any alternate designs

### Benefits

Time saver as shorthand echo is commonly used nowdays and supported since PHP 5.4

### Possible Drawbacks

I do not see any drawbacks

### Applicable Issues

None.
