### PR TITLE
Inline phpdoc

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -178,12 +178,15 @@
   'comments':
     'patterns': [
       {
-        'begin': '/\\*\\*(?:(?:(?:#@\\+)?\\s*$)|\\s+)'
-        'captures':
+        'begin': '(/\\*\\*)(((#@\\+)?\\s*$)|\\s+)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.comment.php'
+        'comment': 'This now only highlights a docblock if the first line contains only /**\n\t\t\t\t\t\t\t\t- this is to stop highlighting everything as invalid when people do comment banners with /******** ...\n\t\t\t\t\t\t\t\t- Now matches /**#@+ too - used for docblock templates: https://codingexplained.com/coding/php/how-to-use-docblock-templates-in-phpdoc'
+        'end': '\\*/'
+        'endCaptures':
           '0':
             'name': 'punctuation.definition.comment.php'
-        'comment': 'This now only highlights a docblock if the first line contains only /**\n\t\t\t\t\t\t\t\t- this is to stop highlighting everything as invalid when people do comment banners with /******** ...\n\t\t\t\t\t\t\t\t- Now matches /**#@+ too - used for docblock templates: http://manual.phpdoc.org/HTMLframesConverter/default/phpDocumentor/tutorial_phpDocumentor.howto.pkg.html#basics.docblocktemplate'
-        'end': '\\s*\\*/'
         'name': 'comment.block.documentation.phpdoc.php'
         'patterns': [
           {

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -180,7 +180,7 @@
       {
         # This only highlights a docblock if the first line contains only two *s
         # to stop highlighting everything as invalid when people do comment banners with /******** ...
-        'begin': '(/\\*\\*)(?=\\s+)'
+        'begin': '(/\\*\\*)(?=\\s)'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.comment.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -180,7 +180,7 @@
       {
         # This only highlights a docblock if the first line contains only two *s
         # to stop highlighting everything as invalid when people do comment banners with /******** ...
-        'begin': '(/\\*\\*)(?=$|\\s+)'
+        'begin': '(/\\*\\*)(?=\\s+)'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.comment.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -178,11 +178,11 @@
   'comments':
     'patterns': [
       {
-        'begin': '(/\\*\\*)(((#@\\+)?\\s*$)|\\s+)'
+        'begin': '(/\\*\\*)($|\\s+)'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.comment.php'
-        'comment': 'This now only highlights a docblock if the first line contains only /**\n\t\t\t\t\t\t\t\t- this is to stop highlighting everything as invalid when people do comment banners with /******** ...\n\t\t\t\t\t\t\t\t- Now matches /**#@+ too - used for docblock templates: https://codingexplained.com/coding/php/how-to-use-docblock-templates-in-phpdoc'
+        'comment': 'This now only highlights a docblock if the first line contains only two *`s - this is to stop highlighting everything as invalid when people do comment banners with /******** ...'
         'end': '\\*/'
         'endCaptures':
           '0':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -192,6 +192,19 @@
         ]
       }
       {
+        'begin': '/\\*\\*\\s+'
+        'captures':
+          '0':
+            'name': 'punctuation.definition.comment.php'
+        'end': '\\s+\\*/'
+        'name': 'comment.block.documentation.phpdoc.php'
+        'patterns': [
+          {
+            'include': '#php_doc'
+          }
+        ]
+      }
+      {
         'begin': '/\\*'
         'captures':
           '0':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -178,11 +178,12 @@
   'comments':
     'patterns': [
       {
-        'begin': '(/\\*\\*)($|\\s+)'
+        # This only highlights a docblock if the first line contains only two *s
+        # to stop highlighting everything as invalid when people do comment banners with /******** ...
+        'begin': '(/\\*\\*)(?=$|\\s+)'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.comment.php'
-        'comment': 'This now only highlights a docblock if the first line contains only two *`s - this is to stop highlighting everything as invalid when people do comment banners with /******** ...'
         'end': '\\*/'
         'endCaptures':
           '0':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -178,25 +178,12 @@
   'comments':
     'patterns': [
       {
-        'begin': '/\\*\\*(?:#@\\+)?\\s*$'
+        'begin': '/\\*\\*(?:(?:(?:#@\\+)?\\s*$)|\\s+)'
         'captures':
           '0':
             'name': 'punctuation.definition.comment.php'
         'comment': 'This now only highlights a docblock if the first line contains only /**\n\t\t\t\t\t\t\t\t- this is to stop highlighting everything as invalid when people do comment banners with /******** ...\n\t\t\t\t\t\t\t\t- Now matches /**#@+ too - used for docblock templates: http://manual.phpdoc.org/HTMLframesConverter/default/phpDocumentor/tutorial_phpDocumentor.howto.pkg.html#basics.docblocktemplate'
-        'end': '\\*/'
-        'name': 'comment.block.documentation.phpdoc.php'
-        'patterns': [
-          {
-            'include': '#php_doc'
-          }
-        ]
-      }
-      {
-        'begin': '/\\*\\*\\s+'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.comment.php'
-        'end': '\\s+\\*/'
+        'end': '\\s*\\*/'
         'name': 'comment.block.documentation.phpdoc.php'
         'patterns': [
           {

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -180,9 +180,9 @@
       {
         # This only highlights a docblock if the first line contains only two *s
         # to stop highlighting everything as invalid when people do comment banners with /******** ...
-        'begin': '(/\\*\\*)(?=\\s)'
+        'begin': '/\\*\\*(?=\\s)'
         'beginCaptures':
-          '1':
+          '0':
             'name': 'punctuation.definition.comment.php'
         'end': '\\*/'
         'endCaptures':

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -343,9 +343,11 @@ describe 'PHP grammar', ->
       it 'should tokenize an inline phpdoc correctly', ->
         tokens = grammar.tokenizeLines "<?php\n/** @var */"
 
-        expect(tokens[1][0]).toEqual value: '/** ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'punctuation.definition.comment.php']
-        expect(tokens[1][1]).toEqual value: '@var', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
-        expect(tokens[1][2]).toEqual value: ' */', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'punctuation.definition.comment.php']
+        expect(tokens[1][0]).toEqual value: '/**', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'punctuation.definition.comment.php']
+        expect(tokens[1][1]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php']
+        expect(tokens[1][2]).toEqual value: '@var', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[1][3]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php']
+        expect(tokens[1][4]).toEqual value: '*/', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'punctuation.definition.comment.php']
 
       it 'should tokenize default value with non-lowercase array type hinting correctly', ->
         tokens = grammar.tokenizeLines "<?php\nfunction array_test(Array $value = []) {}"

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -340,6 +340,13 @@ describe 'PHP grammar', ->
         expect(tokens[2][1]).toEqual value: '@source', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[3][0]).toEqual value: '*/', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'punctuation.definition.comment.php']
 
+      it 'should tokenize an inline phpdoc correctly', ->
+        tokens = grammar.tokenizeLines "<?php\n/** @var */"
+
+        expect(tokens[1][0]).toEqual value: '/** ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'punctuation.definition.comment.php']
+        expect(tokens[1][1]).toEqual value: '@var', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[1][2]).toEqual value: ' */', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'punctuation.definition.comment.php']
+
       it 'should tokenize default value with non-lowercase array type hinting correctly', ->
         tokens = grammar.tokenizeLines "<?php\nfunction array_test(Array $value = []) {}"
 

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -349,6 +349,11 @@ describe 'PHP grammar', ->
         expect(tokens[1][3]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php']
         expect(tokens[1][4]).toEqual value: '*/', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'punctuation.definition.comment.php']
 
+      it 'should not tokenize /*** as phpdoc', ->
+        tokens = grammar.tokenizeLines "<?php\n/*** @var */"
+
+        expect(tokens[1][0].scopes).not.toContain 'comment.block.documentation.phpdoc.php'
+
       it 'should tokenize default value with non-lowercase array type hinting correctly', ->
         tokens = grammar.tokenizeLines "<?php\nfunction array_test(Array $value = []) {}"
 


### PR DESCRIPTION
### Description of the Change

highlight inline phpdoc correctly

```php
/** @var string Variable */
```

### Alternate Designs

We might want to also support single line comments https://github.com/atom/language-php/issues/135#issuecomment-270901684

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

highlight inline phpdoc correctly

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

none

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

#135

<!-- Enter any applicable Issues here -->
