### PR TITLE
support @inheritdoc

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1723,7 +1723,7 @@
         'match': '(@xlink)\\s+(.+)\\s*$'
       }
       {
-        'match': '\\@(a(pi|bstract|uthor)|c(ategory|opyright)|example|global|in(herit|ternal)|li(cense|nk)|method|p(roperty(\\-read|\\-write|)|ackage|aram)|return|s(ee|ince|ource|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|final|ignore)\\b'
+        'match': '\\@(a(pi|bstract|uthor)|c(ategory|opyright)|example|global|in(heritdoc|ternal)|li(cense|nk)|method|p(roperty(\\-read|\\-write|)|ackage|aram)|return|s(ee|ince|ource|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|final|ignore)\\b'
         'name': 'keyword.other.phpdoc.php'
       }
       {

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1489,7 +1489,7 @@
         'match': '(?:(\\=)(&))|(&(?=[$A-Za-z_]))'
       }
       {
-        'match': '(f)'
+        'match': '(@)'
         'name': 'keyword.operator.error-control.php'
       }
       {

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1723,7 +1723,7 @@
         'match': '(@xlink)\\s+(.+)\\s*$'
       }
       {
-        'match': '\\@(a(pi|bstract|uthor)|c(ategory|opyright)|example|global|internal|li(cense|nk)|method|p(roperty(\\-read|\\-write|)|ackage|aram)|return|s(ee|ince|ource|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|final|ignore)\\b'
+        'match': '\\@(a(pi|bstract|uthor)|c(ategory|opyright)|example|global|in(herit|ternal)|li(cense|nk)|method|p(roperty(\\-read|\\-write|)|ackage|aram)|return|s(ee|ince|ource|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|final|ignore)\\b'
         'name': 'keyword.other.phpdoc.php'
       }
       {

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1723,14 +1723,14 @@
         'match': '(@xlink)\\s+(.+)\\s*$'
       }
       {
-        'match': '\\@(a(pi|bstract|uthor)|c(ategory|opyright)|example|global|in(herit|ternal)|li(cense|nk)|method|p(roperty(\\-read|\\-write|)|ackage|aram)|return|s(ee|ince|ource|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|final|ignore)\\b'
+        'match': '\\@(a(pi|bstract|uthor)|c(ategory|opyright)|example|global|internal|li(cense|nk)|method|p(roperty(\\-read|\\-write|)|ackage|aram)|return|s(ee|ince|ource|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|final|ignore)\\b'
         'name': 'keyword.other.phpdoc.php'
       }
       {
         'captures':
           '1':
             'name': 'keyword.other.phpdoc.php'
-        'match': '\\{(@(link)).+?\\}'
+        'match': '\\{(@(link|inheritdoc)).+?\\}'
         'name': 'meta.tag.inline.phpdoc.php'
       }
     ]

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1723,14 +1723,14 @@
         'match': '(@xlink)\\s+(.+)\\s*$'
       }
       {
-        'match': '\\@(a(pi|bstract|uthor)|c(ategory|opyright)|example|global|in(heritdoc|ternal)|li(cense|nk)|method|p(roperty(\\-read|\\-write|)|ackage|aram)|return|s(ee|ince|ource|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|final|ignore)\\b'
+        'match': '\\@(a(pi|bstract|uthor)|c(ategory|opyright)|example|global|in(herit[Dd]oc|ternal)|li(cense|nk)|method|p(roperty(\\-read|\\-write|)|ackage|aram)|return|s(ee|ince|ource|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|final|ignore)\\b'
         'name': 'keyword.other.phpdoc.php'
       }
       {
         'captures':
           '1':
             'name': 'keyword.other.phpdoc.php'
-        'match': '\\{(@(link|inheritdoc)).+?\\}'
+        'match': '\\{(@(link|inherit[Dd]oc)).+?\\}'
         'name': 'meta.tag.inline.phpdoc.php'
       }
     ]

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1489,7 +1489,7 @@
         'match': '(?:(\\=)(&))|(&(?=[$A-Za-z_]))'
       }
       {
-        'match': '(@)'
+        'match': '(f)'
         'name': 'keyword.operator.error-control.php'
       }
       {
@@ -1723,7 +1723,7 @@
         'match': '(@xlink)\\s+(.+)\\s*$'
       }
       {
-        'match': '\\@(a(pi|bstract|uthor)|c(ategory|opyright)|example|global|internal|li(cense|nk)|method|p(roperty(\\-read|\\-write|)|ackage|aram)|return|s(ee|ince|ource|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|final|ignore)\\b'
+        'match': '\\@(a(pi|bstract|uthor)|c(ategory|opyright)|example|global|in(herit|ternal)|li(cense|nk)|method|p(roperty(\\-read|\\-write|)|ackage|aram)|return|s(ee|ince|ource|tatic|ubpackage)|t(hrows|odo)|v(ar|ersion)|uses|deprecated|final|ignore)\\b'
         'name': 'keyword.other.phpdoc.php'
       }
       {


### PR DESCRIPTION
### Description of the Change
Support the phpdoc keyword `@inheritDoc`

### Alternate Designs
It looked the best to me, and I looked after other things had been implemented.

### Benefits
`@inheritDoc` will be marked as a keyword, so the code will be displayed better.

### Possible Drawbacks
I don't know any.

### Applicable Issues
Did I need to create one?
