### PR TITLE
Tokenize $this as variable.language.this.php

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -3182,6 +3182,12 @@
         'name': 'punctuation.definition.variable.php'
     'match': '(\\$)((GLOBALS|_(ENV|SERVER|SESSION)))'
     'name': 'variable.other.global.safer.php'
+  'var_language':
+    'match': '(\\$)this\\b'
+    'name': 'variable.language.this.php'
+    'captures':
+      '1':
+        'name': 'punctuation.definition.variable.php'
   'variable-name':
     'patterns': [
       {
@@ -3236,6 +3242,9 @@
     ]
   'variables':
     'patterns': [
+      {
+        'include': '#var_language'
+      }
       {
         'include': '#var_global'
       }

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -210,6 +210,15 @@ describe 'PHP grammar', ->
         expect(tokens[1][5]).toEqual value: '2', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'constant.numeric.php']
         expect(tokens[1][6]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
 
+  it 'should tokenize $this', ->
+    tokens = grammar.tokenizeLines "<?php $this"
+    expect(tokens[0][2]).toEqual value: '$', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.language.this.php', 'punctuation.definition.variable.php']
+    expect(tokens[0][3]).toEqual value: 'this', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.language.this.php']
+
+    tokens = grammar.tokenizeLines "<?php $thistles"
+    expect(tokens[0][2]).toEqual value: '$', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(tokens[0][3]).toEqual value: 'thistles', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php']
+
   it 'should tokenize namespace at the same line as <?php', ->
     tokens = grammar.tokenizeLines "<?php namespace Test;"
     expect(tokens[0][1]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.namespace.php']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Minimally invasive change to tokenize `$this` as `variable.language.this.php` rather than `variable.other.php`.

### Alternate Designs

None.

### Benefits

Accuracy.

### Possible Drawbacks

None?

### Applicable Issues

Fixes #34, the last surviving issue for the `variable.language.this` update.
