### PR TITLE
Add AND as a valid SQL keyword

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2113,7 +2113,7 @@
     'match': '\\\\(?:\\\\(?:\\\\[\\\\\']?|[^\'])|.)'
     'name': 'constant.character.escape.php'
   'sql-string-double-quoted':
-    'begin': '"\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER)\\b)'
+    'begin': '"\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND)\\b)'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'
@@ -2176,7 +2176,7 @@
       }
     ]
   'sql-string-single-quoted':
-    'begin': '\'\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER)\\b)'
+    'begin': '\'\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND)\\b)'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Simple change to add `AND` as a valid SQL keyword to start a string with.

### Alternate Designs

None.

### Benefits

SQL strings starting with `AND` should be properly highlighted as...SQL strings, rather than regular strings.

### Possible Drawbacks

I foresee some possible issue with someone who _just happens_ to write a regular string that starts with `AND`, maybe "AND...that's the end".  Of course, the same argument is applicable for all the other SQL keywords as well, so I don't think it's that big of a deal.

### Applicable Issues

Fixes #52