### PR TITLE
Add another PHP snippet

### DIFF
--- a/snippets/language-php.cson
+++ b/snippets/language-php.cson
@@ -1,10 +1,14 @@
+'.punctuation.section.embedded.begin.php':
+  'php … ?>':
+    'prefix': 'php'
+    'body': 'php $0 ?>'
 '.source.php':
   '$GLOBALS[\'…\']':
     'prefix': 'globals'
     'body': '$GLOBALS[\'${1:variable}\']${2: = }${3:something}${4:;}$0'
-  '<?php … ?>':
+  '?>…<?php':
     'prefix': 'php'
-    'body': 'php $0 ?>'
+    'body': '?>$0<?php'
   'shorthand echo':
     'prefix': '<?'
     'body': '<?= $0 ?>'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Attempts to simultaneously satisfy #76 and #90.  I'm not too happy with this solution, but accept it because it's been there for two years already and the default ac+ confirm keybinding includes enter.

### Alternate Designs

:fire: the new snippet and only change the old one.  On default installations, this will result in `<?<?php` when trying to press enter after `<?php`.

### Benefits

Please everyone?

### Possible Drawbacks

None.

### Applicable Issues

Fixes #76
Fixes #90