### PR TITLE
Fix inline include not stopping at the closing PHP tag

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1536,7 +1536,7 @@
         'beginCaptures':
           '1':
             'name': 'keyword.control.import.include.php'
-        'end': '(?=\\s|;|$)'
+        'end': '(?=\\s|;|$|\\?>)'
         'name': 'meta.include.php'
         'patterns': [
           {

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -234,6 +234,15 @@ describe 'PHP grammar', ->
     expect(tokens[1][2]).toEqual value: 'Test', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.namespace.php', 'entity.name.type.namespace.php']
     expect(tokens[1][3]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
 
+  it 'should tokenize include on the same line as <?php', ->
+    # https://github.com/atom/language-php/issues/154
+    tokens = grammar.tokenizeLines "<?php include 'test'?>"
+    expect(tokens[0][2]).toEqual value: 'include', scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.include.php', 'keyword.control.import.include.php']
+    expect(tokens[0][4]).toEqual value: "'", scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.include.php', 'string.quoted.single.php', 'punctuation.definition.string.begin.php']
+    expect(tokens[0][6]).toEqual value: "'", scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.include.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
+    expect(tokens[0][7]).toEqual value: '?', scopes: ['text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.end.php', 'source.php']
+    expect(tokens[0][8]).toEqual value: '>', scopes: ['text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.end.php']
+
   it 'should tokenize functions correctly', ->
     tokens = grammar.tokenizeLines "<?php\nfunction test() {}"
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Simple change to add `?>` to the list of valid end patterns when including a PHP file.

### Alternate Designs

None.

### Benefits

`<?php include 'test'?>` syntax will now be properly highlighted.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #154
