### PR TITLE
Tokenize function return values

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1677,10 +1677,14 @@
           '6':
             'name': 'punctuation.definition.parameters.begin.bracket.round.php'
         'contentName': 'meta.function.parameters.php'
-        'end': '\\)'
+        'end': '(\\))(?:\\s*(:)\\s*([a-zA-Z_\\x{7f}-\\x{ff}][a-zA-Z0-9_\\x{7f}-\\x{ff}]*))?'
         'endCaptures':
-          '0':
+          '1':
             'name': 'punctuation.definition.parameters.end.bracket.round.php'
+          '2':
+            'name': 'keyword.operator.return-value.php'
+          '3':
+            'name': 'storage.type.php'
         'name': 'meta.function.php'
         'patterns': [
           {

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -370,6 +370,20 @@ describe 'PHP grammar', ->
       expect(tokens[1][22]).toEqual value: 'null', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'constant.language.php']
       expect(tokens[1][23]).toEqual value: ')', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
 
+    it 'tokenizes return values', ->
+      tokens = grammar.tokenizeLines "<?php\nfunction test() : Client {}"
+
+      expect(tokens[1][0]).toEqual value: 'function', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'storage.type.function.php']
+      expect(tokens[1][1]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php']
+      expect(tokens[1][2]).toEqual value: 'test', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'entity.name.function.php']
+      expect(tokens[1][3]).toEqual value: '(', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
+      expect(tokens[1][4]).toEqual value: ')', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
+      expect(tokens[1][5]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php']
+      expect(tokens[1][6]).toEqual value: ':', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'keyword.operator.return-value.php']
+      expect(tokens[1][7]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php']
+      expect(tokens[1][8]).toEqual value: 'Client', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'storage.type.php']
+      expect(tokens[1][9]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+
   describe 'function calls', ->
     # TODO: Still needs coverage of namespaced function calls
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Consistently tokenize function return values as `storage.type.php`.

### Alternate Designs

None.

### Benefits

Return types will be tokenized correctly.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #197 to an extent - the scopes are still different, but I don't think they should be the same in the first place.