### PR TITLE
Support 'use' in traits

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -212,7 +212,7 @@
                 '''
                 'captures':
                   '1':
-                    'name': 'keyword.operator.use-as.php'
+                    'name': 'keyword.other.use-as.php'
                   '2':
                     'patterns': [
                       {
@@ -231,7 +231,7 @@
                 'match': '(?i)\\b(insteadof)\\s+([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)'
                 'captures':
                   '1':
-                    'name': 'keyword.operator.use-insteadof.php'
+                    'name': 'keyword.other.use-insteadof.php'
                   '2':
                     'name': 'support.class.php'
               }
@@ -1545,7 +1545,7 @@
         ]
       }
       {
-        'begin': '(?i)^\\s*(abstract|final)?\\s*(class)\\s+([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)'
+        'begin': '(?i)^\\s*(?:(abstract|final)\\s+)?(class)\\s+([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)'
         'beginCaptures':
           '1':
             'name': 'storage.modifier.${1:/downcase}.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -138,6 +138,31 @@
   'class-body':
     'patterns': [
       {
+        'match': '''(?xi)
+          \\b(use)\\s+
+          ([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)
+          ((?:\\s*,\\s*[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)*)
+          (?=\\s*;)
+        '''
+        'name': 'meta.use.php'
+        'captures':
+          '1':
+            'name': 'keyword.other.use.php'
+          '2':
+            'name': 'support.class.php'
+          '3':
+            'patterns': [
+              {
+                'match': '(?i)[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*'
+                'name': 'support.class.php'
+              }
+              {
+                'match': ','
+                'name': 'punctuation.separator.delimiter.php'
+              }
+            ]
+      }
+      {
         'begin': '(?i)\\buse\\b'
         'beginCaptures':
           '0':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -135,6 +135,93 @@
   }
 ]
 'repository':
+  'class-body':
+    'patterns': [
+      {
+        'begin': '(?i)\\buse\\b'
+        'beginCaptures':
+          '0':
+            'name': 'keyword.other.use.php'
+        'end': '}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.use.end.bracket.curly.php'
+        'name': 'meta.use.php'
+        'patterns': [
+          {
+            'match': '''(?xi)
+              ([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)
+              ((?:\\s*,\\s*[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)*)
+            '''
+            'captures':
+              '1':
+                'name': 'support.class.php'
+              '2':
+                'patterns': [
+                  {
+                    'match': '(?i)[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*'
+                    'name': 'support.class.php'
+                  }
+                  {
+                    'match': ','
+                    'name': 'punctuation.separator.delimiter.php'
+                  }
+                ]
+          }
+          {
+            'begin': '{'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.use.begin.bracket.curly.php'
+            'end': '(?=})'
+            'contentName': 'meta.use.body.php'
+            'patterns': [
+              {
+                'include': '#scope-resolution'
+              }
+              {
+                'match': '''(?xi)
+                  \\b(as)\\s+
+                  ([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)\\b       # Visibility modifier OR alias
+                  (?:\\s+([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*))? # alias
+                '''
+                'captures':
+                  '1':
+                    'name': 'keyword.operator.use-as.php'
+                  '2':
+                    'patterns': [
+                      {
+                        'match': '\\b(final|abstract|public|private|protected|static)\\b'
+                        'name': 'storage.modifier.php'
+                      }
+                      {
+                        'match': '[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*'
+                        'name': 'entity.other.alias.php'
+                      }
+                    ]
+                  '3':
+                    'name': 'entity.other.alias.php'
+              }
+              {
+                'match': '(?i)\\b(insteadof)\\s+([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)'
+                'captures':
+                  '1':
+                    'name': 'keyword.operator.use-insteadof.php'
+                  '2':
+                    'name': 'support.class.php'
+              }
+              {
+                'match': ';'
+                'name': 'punctuation.terminator.expression.php'
+              }
+            ]
+          }
+        ]
+      }
+      {
+        'include': '#language'
+      }
+    ]
   'class-builtin':
     'patterns': [
       {
@@ -1441,7 +1528,10 @@
             'name': 'storage.type.class.php'
           '3':
             'name': 'entity.name.type.class.php'
-        'end': '(?=[;{])'
+        'end': '}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.class.end.bracket.curly.php'
         'name': 'meta.class.php'
         'patterns': [
           {
@@ -1517,6 +1607,19 @@
                     'name': 'entity.other.inherited-class.php'
                   }
                 ]
+              }
+            ]
+          }
+          {
+            'begin': '{'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.class.begin.bracket.curly.php'
+            'end': '(?=})'
+            'contentName': 'meta.class.body.php'
+            'patterns': [
+              {
+                'include': '#class-body'
               }
             ]
           }
@@ -1696,60 +1799,7 @@
         'include': '#invoke-call'
       }
       {
-        'match': '(?i)\\b([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)(?=\\s*::)'
-        'captures':
-          '1':
-            'patterns': [
-              {
-                'match': '\\b(self|static|parent)\\b'
-                'name': 'storage.type.php'
-              }
-              {
-                'include': '#class-name'
-              }
-              {
-                'include': '#variable-name'
-              }
-            ]
-      }
-      {
-        'begin': '(?i)(::)\\s*([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)\\s*(\\()'
-        'beginCaptures':
-          '1':
-            'name': 'keyword.operator.class.php'
-          '2':
-            'name': 'entity.name.function.php'
-          '3':
-            'name': 'punctuation.definition.arguments.begin.bracket.round.php'
-        'end': '\\)'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.arguments.end.bracket.round.php'
-        'name': 'meta.method-call.static.php'
-        'patterns': [
-          {
-            'include': '#language'
-          }
-        ]
-      }
-      {
-        'match': '''(?xi)
-          (::)\\s*
-          (?:
-            ((\\$+)[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*) # Variable
-            |
-            ([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)       # Constant
-          )?
-        '''
-        'captures':
-          '1':
-            'name': 'keyword.operator.class.php'
-          '2':
-            'name': 'variable.other.class.php'
-          '3':
-            'name': 'punctuation.definition.variable.php'
-          '4':
-            'name': 'constant.other.class.php'
+        'include': '#scope-resolution'
       }
       {
         'include': '#variables'
@@ -2200,6 +2250,65 @@
       {
         'match': '[$^+*]'
         'name': 'keyword.operator.regexp.php'
+      }
+    ]
+  'scope-resolution':
+    'patterns': [
+      {
+        'match': '(?i)\\b([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)(?=\\s*::)'
+        'captures':
+          '1':
+            'patterns': [
+              {
+                'match': '\\b(self|static|parent)\\b'
+                'name': 'storage.type.php'
+              }
+              {
+                'include': '#class-name'
+              }
+              {
+                'include': '#variable-name'
+              }
+            ]
+      }
+      {
+        'begin': '(?i)(::)\\s*([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)\\s*(\\()'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.operator.class.php'
+          '2':
+            'name': 'entity.name.function.php'
+          '3':
+            'name': 'punctuation.definition.arguments.begin.bracket.round.php'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.arguments.end.bracket.round.php'
+        'name': 'meta.method-call.static.php'
+        'patterns': [
+          {
+            'include': '#language'
+          }
+        ]
+      }
+      {
+        'match': '''(?xi)
+          (::)\\s*
+          (?:
+            ((\\$+)[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*) # Variable
+            |
+            ([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)       # Constant
+          )?
+        '''
+        'captures':
+          '1':
+            'name': 'keyword.operator.class.php'
+          '2':
+            'name': 'variable.other.class.php'
+          '3':
+            'name': 'punctuation.definition.variable.php'
+          '4':
+            'name': 'constant.other.class.php'
       }
     ]
   'single_quote_regex_escape':

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -243,6 +243,135 @@ describe 'PHP grammar', ->
     expect(tokens[0][7]).toEqual value: '?', scopes: ['text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.end.php', 'source.php']
     expect(tokens[0][8]).toEqual value: '>', scopes: ['text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.end.php']
 
+  describe 'classes', ->
+    it 'tokenizes class declarations', ->
+      tokens = grammar.tokenizeLines "<?php\nclass Test { /* stuff */ }"
+
+      expect(tokens[1][0]).toEqual value: 'class', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'storage.type.class.php']
+      expect(tokens[1][1]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php']
+      expect(tokens[1][2]).toEqual value: 'Test', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'entity.name.type.class.php']
+      expect(tokens[1][3]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php']
+      expect(tokens[1][4]).toEqual value: '{', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'punctuation.definition.class.begin.bracket.curly.php']
+      expect(tokens[1][5]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php']
+      expect(tokens[1][6]).toEqual value: '/*', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'comment.block.php', 'punctuation.definition.comment.php']
+      expect(tokens[1][10]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'punctuation.definition.class.end.bracket.curly.php']
+
+    it 'tokenizes class modifiers', ->
+      tokens = grammar.tokenizeLines "<?php\nabstract class Test {}"
+
+      expect(tokens[1][0]).toEqual value: 'abstract', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'storage.modifier.abstract.php']
+      expect(tokens[1][1]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php']
+      expect(tokens[1][2]).toEqual value: 'class', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'storage.type.class.php']
+      expect(tokens[1][3]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php']
+      expect(tokens[1][4]).toEqual value: 'Test', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'entity.name.type.class.php']
+
+      tokens = grammar.tokenizeLines "<?php\nfinal class Test {}"
+
+      expect(tokens[1][0]).toEqual value: 'final', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'storage.modifier.final.php']
+      expect(tokens[1][1]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php']
+      expect(tokens[1][2]).toEqual value: 'class', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'storage.type.class.php']
+      expect(tokens[1][3]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php']
+      expect(tokens[1][4]).toEqual value: 'Test', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'entity.name.type.class.php']
+
+    describe "use statements", ->
+      it 'tokenizes basic use statements', ->
+        tokens = grammar.tokenizeLines """
+          <?php
+          class Test {
+            use A;
+          }
+        """
+
+        expect(tokens[2][1]).toEqual value: 'use', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'keyword.other.use.php']
+        expect(tokens[2][2]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php']
+        expect(tokens[2][3]).toEqual value: 'A', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.class.php']
+        expect(tokens[2][4]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'punctuation.terminator.expression.php']
+
+        tokens = grammar.tokenizeLines """
+          <?php
+          class Test {
+            use A, B;
+          }
+        """
+
+        expect(tokens[2][1]).toEqual value: 'use', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'keyword.other.use.php']
+        expect(tokens[2][2]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php']
+        expect(tokens[2][3]).toEqual value: 'A', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.class.php']
+        expect(tokens[2][4]).toEqual value: ',', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'punctuation.separator.delimiter.php']
+        expect(tokens[2][5]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php']
+        expect(tokens[2][6]).toEqual value: 'B', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.class.php']
+        expect(tokens[2][7]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'punctuation.terminator.expression.php']
+
+      it 'tokenizes complex use statements', ->
+        tokens = grammar.tokenizeLines """
+          <?php
+          class Test {
+            use A, B {
+              B::smallTalk insteadof A;
+            }
+          }
+        """
+
+        expect(tokens[2][1]).toEqual value: 'use', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'keyword.other.use.php']
+        expect(tokens[2][2]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php']
+        expect(tokens[2][3]).toEqual value: 'A', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.class.php']
+        expect(tokens[2][4]).toEqual value: ',', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'punctuation.separator.delimiter.php']
+        expect(tokens[2][5]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php']
+        expect(tokens[2][6]).toEqual value: 'B', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.class.php']
+        expect(tokens[2][7]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php']
+        expect(tokens[2][8]).toEqual value: '{', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'punctuation.definition.use.begin.bracket.curly.php']
+        expect(tokens[3][1]).toEqual value: 'B', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'support.class.php']
+        expect(tokens[3][2]).toEqual value: '::', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'keyword.operator.class.php']
+        expect(tokens[3][3]).toEqual value: 'smallTalk', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'constant.other.class.php']
+        expect(tokens[3][4]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php']
+        expect(tokens[3][5]).toEqual value: 'insteadof', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'keyword.other.use-insteadof.php']
+        expect(tokens[3][6]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php']
+        expect(tokens[3][7]).toEqual value: 'A', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'support.class.php']
+        expect(tokens[3][8]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'punctuation.terminator.expression.php']
+        expect(tokens[4][1]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'punctuation.definition.use.end.bracket.curly.php']
+
+      it 'tokenizes aliases', ->
+        tokens = grammar.tokenizeLines """
+          <?php
+          class Aliased_Talker {
+              use A, B {
+                  B::smallTalk as private talk;
+              }
+          }
+        """
+
+        expect(tokens[3][1]).toEqual value: 'B', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'support.class.php']
+        expect(tokens[3][2]).toEqual value: '::', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'keyword.operator.class.php']
+        expect(tokens[3][3]).toEqual value: 'smallTalk', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'constant.other.class.php']
+        expect(tokens[3][4]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php']
+        expect(tokens[3][5]).toEqual value: 'as', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'keyword.other.use-as.php']
+        expect(tokens[3][6]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php']
+        expect(tokens[3][7]).toEqual value: 'private', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'storage.modifier.php']
+        expect(tokens[3][8]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php']
+        expect(tokens[3][9]).toEqual value: 'talk', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'entity.other.alias.php']
+        expect(tokens[3][10]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'punctuation.terminator.expression.php']
+        expect(tokens[4][1]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'punctuation.definition.use.end.bracket.curly.php']
+
+      it 'tokenizes aliases', ->
+        tokens = grammar.tokenizeLines """
+          <?php
+          class Aliased_Talker {
+              use A, B {
+                  B::smallTalk as talk;
+              }
+          }
+        """
+
+        expect(tokens[3][1]).toEqual value: 'B', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'support.class.php']
+        expect(tokens[3][2]).toEqual value: '::', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'keyword.operator.class.php']
+        expect(tokens[3][3]).toEqual value: 'smallTalk', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'constant.other.class.php']
+        expect(tokens[3][4]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php']
+        expect(tokens[3][5]).toEqual value: 'as', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'keyword.other.use-as.php']
+        expect(tokens[3][6]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php']
+        expect(tokens[3][7]).toEqual value: 'talk', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'entity.other.alias.php']
+        expect(tokens[3][8]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'punctuation.terminator.expression.php']
+        expect(tokens[4][1]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'punctuation.definition.use.end.bracket.curly.php']
+
   describe 'functions', ->
     it 'tokenizes functions with no arguments', ->
       tokens = grammar.tokenizeLines "<?php\nfunction test() {}"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Adds support for the `use` directive in classes.  In order to differentiate this from the existing `use` namespace syntax, I had to extend the class begin/end to cover the entire class, similar to what Java does.

/cc @jens1o, @Ingramz, @UziTech - any comments on my scope naming?  Anything that I missed?  Mostly I just made sure that the examples at http://php.net/manual/en/language.oop5.traits.php all worked.

### Alternate Designs

None.

### Benefits

First off, the obvious benefit: trait use syntax will be tokenized correctly.  Next, the not-so-obvious benefit: the class regex will be setting a precedent for how to cover entire blocks, rather than just the section up to the block start.

### Possible Drawbacks

I don't think there will be any.

### Applicable Issues

Fixes #127
Fixes #200