### PR TITLE
Add basic specs for embedded SQL

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2219,12 +2219,18 @@
     'name': 'string.quoted.double.sql.php'
     'patterns': [
       {
-        'match': '#(\\\\"|[^"])*(?="|$)'
+        'match': '(#)(\\\\"|[^"])*(?="|$)'
         'name': 'comment.line.number-sign.sql'
+        'captures':
+          '1':
+            'name': 'punctuation.definition.comment.sql'
       }
       {
-        'match': '--(\\\\"|[^"])*(?="|$)'
+        'match': '(--)(\\\\"|[^"])*(?="|$)'
         'name': 'comment.line.double-dash.sql'
+        'captures':
+          '1':
+            'name': 'punctuation.definition.comment.sql'
       }
       {
         'match': '\\\\[\\\\"`\']'
@@ -2282,12 +2288,18 @@
     'name': 'string.quoted.single.sql.php'
     'patterns': [
       {
-        'match': '#(\\\\\'|[^\'])*(?=\'|$)'
+        'match': '(#)(\\\\\'|[^\'])*(?=\'|$)'
         'name': 'comment.line.number-sign.sql'
+        'captures':
+          '1':
+            'name': 'punctuation.definition.comment.sql'
       }
       {
-        'match': '--(\\\\\'|[^\'])*(?=\'|$)'
+        'match': '(--)(\\\\\'|[^\'])*(?=\'|$)'
         'name': 'comment.line.double-dash.sql'
+        'captures':
+          '1':
+            'name': 'punctuation.definition.comment.sql'
       }
       {
         'match': '\\\\[\\\\\'`"]'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Wanted to make sure we get some basic specs in for #187.  Comments also have punctuation scopes now.

### Alternate Designs

None.

### Benefits

Protect against regressions, make comments appear identical to the SQL version.

### Possible Drawbacks

None.

### Applicable Issues

Refs #187