### PR TITLE
Tokenize the special 'class' keyword when used in scope resolution

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2317,6 +2317,14 @@
         ]
       }
       {
+        'match': '(?i)(::)\\s*(class)\\b'
+        'captures':
+          '1':
+            'name': 'keyword.operator.class.php'
+          '2':
+            'name': 'keyword.other.class.php'
+      }
+      {
         'match': '''(?xi)
           (::)\\s*
           (?:

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -711,6 +711,13 @@ describe 'PHP grammar', ->
       expect(tokens[1][3]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
       expect(tokens[1][4]).toEqual value: 'class', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.other.class.php']
 
+      # Should NOT be tokenized as `keyword.other.class`
+      tokens = grammar.tokenizeLines "<?php\nobj::classic"
+
+      expect(tokens[1][0]).toEqual value: 'obj', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'support.class.php']
+      expect(tokens[1][1]).toEqual value: '::', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.class.php']
+      expect(tokens[1][2]).toEqual value: 'classic', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'constant.other.class.php']
+
   describe 'try/catch', ->
     it 'tokenizes a basic try/catch block', ->
       tokens = grammar.tokenizeLines "<?php\ntry {} catch(Exception $e) {}"

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -696,6 +696,21 @@ describe 'PHP grammar', ->
       expect(tokens[1][3]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
       expect(tokens[1][4]).toEqual value: 'constant', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'constant.other.class.php']
 
+    it 'tokenizes the special "class" keyword', ->
+      tokens = grammar.tokenizeLines "<?php\nobj::class"
+
+      expect(tokens[1][0]).toEqual value: 'obj', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'support.class.php']
+      expect(tokens[1][1]).toEqual value: '::', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.class.php']
+      expect(tokens[1][2]).toEqual value: 'class', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.other.class.php']
+
+      tokens = grammar.tokenizeLines "<?php\nobj :: class"
+
+      expect(tokens[1][0]).toEqual value: 'obj', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'support.class.php']
+      expect(tokens[1][1]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+      expect(tokens[1][2]).toEqual value: '::', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.class.php']
+      expect(tokens[1][3]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+      expect(tokens[1][4]).toEqual value: 'class', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.other.class.php']
+
   describe 'try/catch', ->
     it 'tokenizes a basic try/catch block', ->
       tokens = grammar.tokenizeLines "<?php\ntry {} catch(Exception $e) {}"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Does exactly what the title says.

### Alternate Designs

`constant.language.class.php` was considered, but constants generally don't change on context, whereas `class` does.

### Benefits

Scope will be more correct.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #125