### PR TITLE
Add structure to switch statements

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1651,6 +1651,9 @@
         ]
       }
       {
+        'include': '#switch_statement'
+      }
+      {
         'match': '''(?x)
           \\b(
             break|case|continue|declare|default|die|do|
@@ -3402,6 +3405,75 @@
       {
         'match': '(?i)\\bis_int(eger)?\\b'
         'name': 'support.function.alias.php'
+      }
+    ]
+  'switch_statement':
+    'patterns': [
+      {
+        # switch(expression) {...}
+        # but NOT switch(expression):
+        'begin': '\\bswitch\\b(?!\\s*\\(.*\\)\\s*:)'
+        'beginCaptures':
+          '0':
+            'name': 'keyword.control.switch.php'
+        'end': '}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.section.switch-block.end.bracket.curly.php'
+        'name': 'meta.switch-statement.php'
+        'patterns': [
+          {
+            'begin': '\\('
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.switch-expression.begin.bracket.round.php'
+            'end': '\\)'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.definition.switch-expression.end.bracket.round.php'
+            'patterns': [
+              {
+                'include': '#language'
+              }
+            ]
+          }
+          {
+            'begin': '{'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.section.switch-block.begin.bracket.curly.php'
+            'end': '(?=})'
+            'patterns': [
+              {
+                'begin': '\\bcase\\b'
+                'beginCaptures':
+                  '0':
+                    'name': 'keyword.control.case.php'
+                'end': ':'
+                'endCaptures':
+                  '0':
+                    'name': 'punctuation.terminator.statement.php'
+                'patterns': [
+                  {
+                    'include': '#language'
+                  }
+                ]
+              }
+              {
+                # Leading whitespace match is to overrule goto-label regex
+                'match': '(?:^\\s*)?\\b(default)\\s*(:)'
+                'captures':
+                  '1':
+                    'name': 'keyword.control.default.php'
+                  '2':
+                    'name': 'punctuation.terminator.statement.php'
+              }
+              {
+                'include': '#language'
+              }
+            ]
+          }
+        ]
       }
     ]
   'var_basic':

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -769,6 +769,41 @@ describe 'PHP grammar', ->
       expect(tokens[1][21]).toEqual value: '{', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.section.scope.begin.php']
       expect(tokens[1][22]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.section.scope.end.php']
 
+  it 'should tokenize switch statements correctly', ->
+    tokens = grammar.tokenizeLines """
+      <?php
+      switch($something)
+      {
+        case 'string':
+          return 1;
+        case 1:
+          break;
+        default:
+          continue;
+      }
+    """
+
+    expect(tokens[1][0]).toEqual value: 'switch', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'keyword.control.switch.php']
+    expect(tokens[1][1]).toEqual value: '(', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'punctuation.definition.switch-expression.begin.bracket.round.php']
+    expect(tokens[1][2]).toEqual value: '$', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(tokens[1][3]).toEqual value: 'something', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'variable.other.php']
+    expect(tokens[1][4]).toEqual value: ')', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'punctuation.definition.switch-expression.end.bracket.round.php']
+    expect(tokens[2][0]).toEqual value: '{', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'punctuation.definition.section.switch-block.begin.bracket.curly.php']
+    expect(tokens[3][1]).toEqual value: 'case', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'keyword.control.case.php']
+    expect(tokens[3][2]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php']
+    expect(tokens[3][3]).toEqual value: "'", scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'string.quoted.single.php', 'punctuation.definition.string.begin.php']
+    expect(tokens[3][6]).toEqual value: ':', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'punctuation.terminator.statement.php']
+    expect(tokens[4][1]).toEqual value: 'return', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'keyword.control.php']
+    expect(tokens[5][1]).toEqual value: 'case', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'keyword.control.case.php']
+    expect(tokens[5][2]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php']
+    expect(tokens[5][3]).toEqual value: '1', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'constant.numeric.php']
+    expect(tokens[5][4]).toEqual value: ':', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'punctuation.terminator.statement.php']
+    expect(tokens[6][1]).toEqual value: 'break', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'keyword.control.php']
+    expect(tokens[7][1]).toEqual value: 'default', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'keyword.control.default.php']
+    expect(tokens[7][2]).toEqual value: ':', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'punctuation.terminator.statement.php']
+    expect(tokens[8][1]).toEqual value: 'continue', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'keyword.control.php']
+    expect(tokens[9][0]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.switch-statement.php', 'punctuation.definition.section.switch-block.end.bracket.curly.php']
+
   it 'should tokenize storage types correctly', ->
     tokens = grammar.tokenizeLines "<?php\n(int)"
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Mostly a direct copy of language-javascript's `switch_statement` pattern.  Adds new scopes to switch statements and fixes `default:` being recognized as a goto-label.

### Alternate Designs

A less drastic fix would be to create a separate regex for `default:`.

### Benefits

Improved captures, `default:` correctly highlighted (but only inside a switch statement).

### Possible Drawbacks

The alternative control-style syntax is not affected by these changes.

### Applicable Issues

Fixes #226