### PR TITLE
Functions themselves cannot be passed-by-reference

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1775,8 +1775,7 @@
       {
         'begin': '''(?x)
           ((?:(?:final|abstract|public|private|protected|static)\\s+)*)
-          (function)
-          \\s+
+          (function)\\s+
           (?i:
             (__(?:call|construct|debugInfo|destruct|get|set|isset|unset|tostring|
                   clone|set_state|sleep|wakeup|autoload|invoke|callStatic))

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -707,7 +707,7 @@
       {
         'begin': '''(?xi)
           ([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)                               # Typehinted class name
-          \\s*((&)?\\s*(\\.\\.\\.)?(\\$+)[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*) # Variable name with possible reference
+          \\s+((&)?\\s*(\\.\\.\\.)?(\\$+)[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*) # Variable name with possible reference
         '''
         'beginCaptures':
           '1':
@@ -1722,12 +1722,10 @@
         'name': 'keyword.control.exception.php'
       }
       {
-        'begin': '(?i)\\b(function)\\s*(&)?\\s*(?=\\()'
+        'begin': '(?i)\\b(function)\\s*(?=\\()'
         'beginCaptures':
           '1':
             'name': 'storage.type.function.php'
-          '2':
-            'name': 'storage.modifier.reference.php'
         'end': '(?={)'
         'name': 'meta.function.closure.php'
         'patterns': [
@@ -1778,7 +1776,7 @@
         'begin': '''(?x)
           ((?:(?:final|abstract|public|private|protected|static)\\s+)*)
           (function)
-          \\s*(&)?\\s*
+          \\s+
           (?i:
             (__(?:call|construct|debugInfo|destruct|get|set|isset|unset|tostring|
                   clone|set_state|sleep|wakeup|autoload|invoke|callStatic))
@@ -1797,12 +1795,10 @@
           '2':
             'name': 'storage.type.function.php'
           '3':
-            'name': 'storage.modifier.reference.php'
-          '4':
             'name': 'support.function.magic.php'
-          '5':
+          '4':
             'name': 'entity.name.function.php'
-          '6':
+          '5':
             'name': 'punctuation.definition.parameters.begin.bracket.round.php'
         'contentName': 'meta.function.parameters.php'
         'end': '(\\))(?:\\s*(:)\\s*([a-zA-Z_\\x{7f}-\\x{ff}][a-zA-Z0-9_\\x{7f}-\\x{ff}]*))?'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -519,6 +519,8 @@ describe 'PHP grammar', ->
       expect(tokens[1][9]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
 
     it 'tokenizes function names with characters other than letters or numbers', ->
+      # The space between foo and bar is a nbsp (char 160/hex 0xA0), not an actual space (char 32/hex 0x20)
+      # 0xA0 is between 0x7F and 0xFF, making it a valid PHP identifier
       tokens = grammar.tokenizeLines "<?php\nfunction foo bar() {}"
 
       expect(tokens[1][0]).toEqual value: 'function', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'storage.type.function.php']

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -382,6 +382,11 @@ describe 'PHP grammar', ->
       expect(tokens[1][3]).toEqual value: '(', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
       expect(tokens[1][4]).toEqual value: ')', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
 
+      # Should NOT be tokenized as an actual function
+      tokens = grammar.tokenizeLines "<?php\nfunction_test() {}"
+
+      expect(tokens[1][0]).toEqual value: 'function_test', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'entity.name.function.php']
+
     it 'tokenizes default array type with old array value', ->
       tokens = grammar.tokenizeLines "<?php\nfunction array_test(array $value = array()) {}"
 
@@ -512,6 +517,18 @@ describe 'PHP grammar', ->
       expect(tokens[1][7]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php']
       expect(tokens[1][8]).toEqual value: 'Client', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'storage.type.php']
       expect(tokens[1][9]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+
+    it 'tokenizes function names with characters other than letters or numbers', ->
+      tokens = grammar.tokenizeLines "<?php\nfunction foo bar() {}"
+
+      expect(tokens[1][0]).toEqual value: 'function', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'storage.type.function.php']
+      expect(tokens[1][1]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php']
+      expect(tokens[1][2]).toEqual value: 'foo bar', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'entity.name.function.php']
+      expect(tokens[1][3]).toEqual value: '(', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
+      expect(tokens[1][4]).toEqual value: ')', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
+      expect(tokens[1][5]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+      expect(tokens[1][6]).toEqual value: '{', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.section.scope.begin.php']
+      expect(tokens[1][7]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.section.scope.end.php']
 
   describe 'function calls', ->
     # TODO: Still needs coverage of namespaced function calls
@@ -1800,18 +1817,6 @@ describe 'PHP grammar', ->
     expect(tokens[2][2]).toEqual value: '/', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.nowdoc.php', 'string.regexp.nowdoc.php']
     expect(tokens[3][0]).toEqual value: 'REGEXP', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.nowdoc.php', 'punctuation.section.embedded.end.php', 'keyword.operator.nowdoc.php']
     expect(tokens[3][1]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
-
-  it 'should tokenize function name with other characters than letters or numbers', ->
-    tokens = grammar.tokenizeLines "<?php\nfunction foo bar() {}"
-
-    expect(tokens[1][0]).toEqual value: 'function', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'storage.type.function.php']
-    expect(tokens[1][1]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php']
-    expect(tokens[1][2]).toEqual value: 'foo bar', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'entity.name.function.php']
-    expect(tokens[1][3]).toEqual value: '(', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
-    expect(tokens[1][4]).toEqual value: ')', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
-    expect(tokens[1][5]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
-    expect(tokens[1][6]).toEqual value: '{', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.section.scope.begin.php']
-    expect(tokens[1][7]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.section.scope.end.php']
 
   describe 'punctuation', ->
     it 'tokenizes parentheses', ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Fixes a faulty word boundary check when declaring `function`s.  Basically, `function_nope` would still be tokenized as a function because we were incorrectly looking for an optional pass-by-reference indicator, itself surrounded by optional whitespace.  There was no required whitespace or word boundary.

### Alternate Designs

None.

### Benefits

Fixes functions.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #224 