### PR TITLE
Support deeply-namespaced function calls

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -810,7 +810,13 @@
     'patterns': [
       {
         # Functions in a user-defined namespace (overrides any built-ins)
-        'begin': '(?i)(\\\\?[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*\\\\[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)\\s*(\\()'
+        'begin': '''(?xi)
+          (
+            \\\\?\\b                                                # Optional root namespace
+            [a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*          # First namespace
+            (?:\\\\[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)+ # Additional namespaces
+          )\\s*(\\()
+        '''
         'beginCaptures':
           '1':
             'patterns': [
@@ -840,7 +846,11 @@
         'begin': '(?i)(\\\\)?\\b([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)\\s*(\\()'
         'beginCaptures':
           '1':
-            'name': 'punctuation.separator.inheritance.php'
+            'patterns': [
+              {
+                'include': '#namespace'
+              }
+            ]
           '2':
             'patterns': [
               {

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -567,8 +567,6 @@ describe 'PHP grammar', ->
       expect(tokens[1][7]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.section.scope.end.php']
 
   describe 'function calls', ->
-    # TODO: Still needs coverage of namespaced function calls
-
     it 'tokenizes function calls with no arguments', ->
       tokens = grammar.tokenizeLines "<?php\ninverse()"
 
@@ -628,6 +626,53 @@ describe 'PHP grammar', ->
       expect(tokens[1][4]).toEqual value: 'Hi!', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'string.quoted.single.php']
       expect(tokens[1][5]).toEqual value: "'", scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
       expect(tokens[1][6]).toEqual value: ')', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'punctuation.definition.arguments.end.bracket.round.php']
+
+    it 'tokenizes root-namespaced function calls', ->
+      tokens = grammar.tokenizeLines "<?php\n\\test()"
+
+      expect(tokens[1][0]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[1][1]).toEqual value: 'test', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'entity.name.function.php']
+
+    it 'tokenizes user-namespaced function calls', ->
+      tokens = grammar.tokenizeLines "<?php\nhello\\test()"
+
+      expect(tokens[1][0]).toEqual value: 'hello', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'support.other.namespace.php']
+      expect(tokens[1][1]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[1][2]).toEqual value: 'test', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'entity.name.function.php']
+
+      tokens = grammar.tokenizeLines "<?php\none\\two\\test()"
+
+      expect(tokens[1][0]).toEqual value: 'one', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'support.other.namespace.php']
+      expect(tokens[1][1]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[1][2]).toEqual value: 'two', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'support.other.namespace.php']
+      expect(tokens[1][3]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[1][4]).toEqual value: 'test', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'entity.name.function.php']
+
+    it 'tokenizes absolutely-namespaced function calls', ->
+      tokens = grammar.tokenizeLines "<?php\n\\hello\\test()"
+
+      expect(tokens[1][0]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[1][1]).toEqual value: 'hello', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'support.other.namespace.php']
+      expect(tokens[1][2]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[1][3]).toEqual value: 'test', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'entity.name.function.php']
+
+      tokens = grammar.tokenizeLines "<?php\n\\one\\two\\test()"
+
+      expect(tokens[1][0]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[1][1]).toEqual value: 'one', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'support.other.namespace.php']
+      expect(tokens[1][2]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[1][3]).toEqual value: 'two', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'support.other.namespace.php']
+      expect(tokens[1][4]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[1][5]).toEqual value: 'test', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'entity.name.function.php']
+
+    it 'does not treat user-namespaced functions as builtins', ->
+      tokens = grammar.tokenizeLines "<?php\nhello\\apc_store()"
+
+      expect(tokens[1][2]).toEqual value: 'apc_store', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'entity.name.function.php']
+
+      tokens = grammar.tokenizeLines "<?php\n\\hello\\apc_store()"
+
+      expect(tokens[1][3]).toEqual value: 'apc_store', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.function-call.php', 'entity.name.function.php']
 
   describe 'method calls', ->
     it 'tokenizes method calls with no arguments', ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I forgot to make the namespace capture repeat, so at most one namespace would be captured.  The capture now repeats and specs have been added (getting rid of a todo, yay!).

An additional minor change adds the `support.other.namespace.php` token to root function calls.

### Alternate Designs

N/A

### Benefits

See above.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #233