### PR TITLE
move clone operator out of storage.modifier

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1947,7 +1947,7 @@
       }
       {
         'match': '(?i)\\bclone\\b'
-        'name': 'keyword.operator.clone.php'
+        'name': 'keyword.other.clone.php'
       }
       {
         'match': '\\.=?'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1928,7 +1928,7 @@
             'name': 'punctuation.definition.storage-type.end.bracket.round.php'
       }
       {
-        'match': '(?i)\\b(array|real|double|float|int(eger)?|bool(ean)?|string|class|clone|var|function|interface|trait|parent|self|object)\\b'
+        'match': '(?i)\\b(array|real|double|float|int(eger)?|bool(ean)?|string|class|var|function|interface|trait|parent|self|object)\\b'
         'name': 'storage.type.php'
       }
       {
@@ -1944,6 +1944,10 @@
       }
       {
         'include': '#heredoc'
+      }
+      {
+        'match': '(?i)\\bclone'
+        'name': 'keyword.operator.clone.php'
       }
       {
         'match': '\\.=?'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1946,7 +1946,7 @@
         'include': '#heredoc'
       }
       {
-        'match': '(?i)\\bclone'
+        'match': '(?i)\\bclone\\b'
         'name': 'keyword.operator.clone.php'
       }
       {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
see #247 

The `clone` operator is not a storage type, but instead a keyword, so I moved it out. 

### Alternate Designs
Move it to a different location?

### Benefits
More precise syntax highlighting.

### Possible Drawbacks
Theme makers may have to restyle it, but most themes just use the `keyword` global scope, so most of them are not affected.

### Applicable Issues

#247 