### PR TITLE
Fix #235 - support \ in use statements

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -140,8 +140,8 @@
       {
         'match': '''(?xi)
           \\b(use)\\s+
-          ([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)
-          ((?:\\s*,\\s*[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)*)
+          ([a-z_\\x{7f}-\\x{ff}\\\\][a-z0-9_\\x{7f}-\\x{ff}\\\\]*)
+          ((?:\\s*,\\s*[a-z_\\x{7f}-\\x{ff}\\\\][a-z0-9_\\x{7f}-\\x{ff}\\\\]*)*)
           (?=\\s*;)
         '''
         'name': 'meta.use.php'
@@ -153,7 +153,7 @@
           '3':
             'patterns': [
               {
-                'match': '(?i)[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*'
+                'match': '(?i)[a-z_\\x{7f}-\\x{ff}\\\\][a-z0-9_\\x{7f}-\\x{ff}\\\\]*'
                 'name': 'support.class.php'
               }
               {
@@ -175,8 +175,8 @@
         'patterns': [
           {
             'match': '''(?xi)
-              ([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)
-              ((?:\\s*,\\s*[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)*)
+              ([a-z_\\x{7f}-\\x{ff}\\\\][a-z0-9_\\x{7f}-\\x{ff}\\\\]*)
+              ((?:\\s*,\\s*[a-z_\\x{7f}-\\x{ff}\\\\][a-z0-9_\\x{7f}-\\x{ff}\\\\]*)*)
             '''
             'captures':
               '1':
@@ -184,7 +184,7 @@
               '2':
                 'patterns': [
                   {
-                    'match': '(?i)[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*'
+                    'match': '(?i)[a-z_\\x{7f}-\\x{ff}\\\\][a-z0-9_\\x{7f}-\\x{ff}\\\\]*'
                     'name': 'support.class.php'
                   }
                   {

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -149,12 +149,15 @@
           '1':
             'name': 'keyword.other.use.php'
           '2':
-            'name': 'support.class.php'
+            'patterns': [
+              {
+                'include': '#class-name'
+              }
+            ]
           '3':
             'patterns': [
               {
-                'match': '(?i)[a-z_\\x{7f}-\\x{ff}\\\\][a-z0-9_\\x{7f}-\\x{ff}\\\\]*'
-                'name': 'support.class.php'
+                'include': '#class-name'
               }
               {
                 'match': ','
@@ -180,12 +183,15 @@
             '''
             'captures':
               '1':
-                'name': 'support.class.php'
+                'patterns': [
+                  {
+                    'include': '#class-name'
+                  }
+                ]
               '2':
                 'patterns': [
                   {
-                    'match': '(?i)[a-z_\\x{7f}-\\x{ff}\\\\][a-z0-9_\\x{7f}-\\x{ff}\\\\]*'
-                    'name': 'support.class.php'
+                    'include': '#class-name'
                   }
                   {
                     'match': ','

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -517,6 +517,20 @@ describe 'PHP grammar', ->
         expect(tokens[2][6]).toEqual value: 'B', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.class.php']
         expect(tokens[2][7]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'punctuation.terminator.expression.php']
 
+        tokens = grammar.tokenizeLines """
+          <?php
+          class Test {
+            use A\\B;
+          }
+        """
+
+        expect(tokens[2][1]).toEqual value: 'use', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'keyword.other.use.php']
+        expect(tokens[2][2]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php']
+        expect(tokens[2][3]).toEqual value: 'A', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.other.namespace.php']
+        expect(tokens[2][4]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+        expect(tokens[2][5]).toEqual value: 'B', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.class.php']
+        expect(tokens[2][6]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'punctuation.terminator.expression.php']
+
       it 'tokenizes complex use statements', ->
         tokens = grammar.tokenizeLines """
           <?php


### PR DESCRIPTION
This fixes #235. It doesn't make use of `#class-name` as originally suggested, and maybe that would be a slightly better fix, but I couldn't get it to work - https://github.com/atom/language-php/issues/235#issuecomment-318920488. But this works and makes sense.