### PR TITLE
End PHPDoc even if there are malformed types

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2302,7 +2302,7 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.type.begin.bracket.round.phpdoc.php'
-    'end': '(\\))(\\[\\])'
+    'end': '(\\))(\\[\\])|(?=\\*/)'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.type.end.bracket.round.phpdoc.php'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1313,6 +1313,11 @@ describe 'PHP grammar', ->
         expect(tokens[2][21]).toEqual value: '[]', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.array.phpdoc.php']
         expect(tokens[2][22]).toEqual value: ' description', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php']
 
+      it 'should end the PHPDoc at the ending comment even if there are malformed types', ->
+        tokens = grammar.tokenizeLines "<?php\n/** @var array(string) */"
+
+        expect(tokens[1][8]).toEqual value: '*/', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'comment.block.documentation.phpdoc.php', 'punctuation.definition.comment.php']
+
     it 'should not tokenize /*** as phpdoc', ->
       tokens = grammar.tokenizeLines "<?php\n/*** @var */"
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Adds a backup lookahead for the `*/` in case the PHPDoc types are improperly closed.

### Alternate Designs

None.

### Benefits

Comments should always end now.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #245
