### PR TITLE
Combine class use patterns

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1540,7 +1540,7 @@
             'name': 'keyword.other.use.php'
           '2':
             'name': 'storage.type.${2:/downcase}.php'
-        'end': '(?=;|(?:^\\s*$))'
+        'end': '(?=;)'
         'name': 'meta.use.php'
         'patterns': [
           {

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -138,73 +138,36 @@
   'class-body':
     'patterns': [
       {
-        'match': '''(?xi)
-          \\b(use)\\s+
-          ([a-z_\\x{7f}-\\x{ff}\\\\][a-z0-9_\\x{7f}-\\x{ff}\\\\]*)
-          ((?:\\s*,\\s*[a-z_\\x{7f}-\\x{ff}\\\\][a-z0-9_\\x{7f}-\\x{ff}\\\\]*)*)
-          (?=\\s*;)
-        '''
-        'name': 'meta.use.php'
-        'captures':
-          '1':
-            'name': 'keyword.other.use.php'
-          '2':
-            'patterns': [
-              {
-                'include': '#class-name'
-              }
-            ]
-          '3':
-            'patterns': [
-              {
-                'include': '#class-name'
-              }
-              {
-                'match': ','
-                'name': 'punctuation.separator.delimiter.php'
-              }
-            ]
-      }
-      {
         'begin': '(?i)\\buse\\b'
         'beginCaptures':
           '0':
             'name': 'keyword.other.use.php'
-        'end': '}'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.use.end.bracket.curly.php'
+        'end': '(?=;)'
         'name': 'meta.use.php'
         'patterns': [
           {
-            'match': '''(?xi)
-              ([a-z_\\x{7f}-\\x{ff}\\\\][a-z0-9_\\x{7f}-\\x{ff}\\\\]*)
-              ((?:\\s*,\\s*[a-z_\\x{7f}-\\x{ff}\\\\][a-z0-9_\\x{7f}-\\x{ff}\\\\]*)*)
-            '''
+            'match': '(?i)[a-z_\\x{7f}-\\x{ff}\\\\][a-z0-9_\\x{7f}-\\x{ff}\\\\]*'
             'captures':
-              '1':
+              '0':
                 'patterns': [
                   {
                     'include': '#class-name'
                   }
                 ]
-              '2':
-                'patterns': [
-                  {
-                    'include': '#class-name'
-                  }
-                  {
-                    'match': ','
-                    'name': 'punctuation.separator.delimiter.php'
-                  }
-                ]
+          }
+          {
+            'match': ','
+            'name': 'punctuation.separator.delimiter.php'
           }
           {
             'begin': '{'
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.use.begin.bracket.curly.php'
-            'end': '(?=})'
+            'end': '}'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.definition.use.end.bracket.curly.php'
             'contentName': 'meta.use.body.php'
             'patterns': [
               {
@@ -3650,7 +3613,7 @@
       }
       {
         'match': ','
-        'name': 'punctuation.definition.separator.delimiter.php'
+        'name': 'punctuation.separator.delimiter.php'
       }
     ]
   'var_basic':

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -370,6 +370,23 @@ describe 'PHP grammar', ->
       expect(tokens[1][6]).toEqual value: 'NSname', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'support.class.php']
       expect(tokens[1][7]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
 
+    it 'tokenizes multiline use statements', ->
+      tokens = grammar.tokenizeLines """
+        <?php
+          use One\\Two,
+              Three\\Four;
+      """
+
+      expect(tokens[1][1]).toEqual value: 'use', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'keyword.other.use.php']
+      expect(tokens[1][3]).toEqual value: 'One', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'support.other.namespace.php']
+      expect(tokens[1][4]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[1][5]).toEqual value: 'Two', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'support.class.php']
+      expect(tokens[1][6]).toEqual value: ',', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'punctuation.separator.delimiter.php']
+      expect(tokens[2][1]).toEqual value: 'Three', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'support.other.namespace.php']
+      expect(tokens[2][2]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[2][3]).toEqual value: 'Four', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'support.class.php']
+      expect(tokens[2][4]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
+
     it 'tokenizes use function statements', ->
       tokens = grammar.tokenizeLines "<?php\nuse function My\\Full\\functionName;"
 
@@ -422,7 +439,7 @@ describe 'PHP grammar', ->
       expect(tokens[1][6]).toEqual value: 'Classname', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'support.class.php']
       expect(tokens[1][8]).toEqual value: 'as', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'keyword.other.use-as.php']
       expect(tokens[1][10]).toEqual value: 'Another', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'support.other.namespace.use-as.php']
-      expect(tokens[1][11]).toEqual value: ',', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'punctuation.definition.separator.delimiter.php']
+      expect(tokens[1][11]).toEqual value: ',', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'punctuation.separator.delimiter.php']
       expect(tokens[1][12]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php']
       expect(tokens[1][13]).toEqual value: 'My', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'support.other.namespace.php']
       expect(tokens[1][14]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
@@ -447,9 +464,9 @@ describe 'PHP grammar', ->
       expect(tokens[1][5]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
       expect(tokens[1][6]).toEqual value: '{', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'punctuation.definition.use.group.begin.bracket.curly.php']
       expect(tokens[2][1]).toEqual value: 'ClassA', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'support.class.php']
-      expect(tokens[2][2]).toEqual value: ',', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'punctuation.definition.separator.delimiter.php']
+      expect(tokens[2][2]).toEqual value: ',', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'punctuation.separator.delimiter.php']
       expect(tokens[3][1]).toEqual value: 'ClassB', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'support.class.php']
-      expect(tokens[3][2]).toEqual value: ',', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'punctuation.definition.separator.delimiter.php']
+      expect(tokens[3][2]).toEqual value: ',', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'punctuation.separator.delimiter.php']
       expect(tokens[4][1]).toEqual value: 'ClassC', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'support.class.php']
       expect(tokens[4][2]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php']
       expect(tokens[4][3]).toEqual value: 'as', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.use.php', 'keyword.other.use-as.php']
@@ -530,6 +547,25 @@ describe 'PHP grammar', ->
         expect(tokens[2][4]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
         expect(tokens[2][5]).toEqual value: 'B', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.class.php']
         expect(tokens[2][6]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'punctuation.terminator.expression.php']
+
+      it 'tokenizes multiline use statements', ->
+        tokens = grammar.tokenizeLines """
+          <?php
+            class Test {
+              use One\\Two,
+                  Three\\Four;
+            }
+        """
+
+        expect(tokens[2][1]).toEqual value: 'use', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'keyword.other.use.php']
+        expect(tokens[2][3]).toEqual value: 'One', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.other.namespace.php']
+        expect(tokens[2][4]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+        expect(tokens[2][5]).toEqual value: 'Two', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.class.php']
+        expect(tokens[2][6]).toEqual value: ',', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'punctuation.separator.delimiter.php']
+        expect(tokens[3][1]).toEqual value: 'Three', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.other.namespace.php']
+        expect(tokens[3][2]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+        expect(tokens[3][3]).toEqual value: 'Four', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'support.class.php']
+        expect(tokens[3][4]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'punctuation.terminator.expression.php']
 
       it 'tokenizes complex use statements', ->
         tokens = grammar.tokenizeLines """


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* Combine the two class `use` patterns into one, because I didn't see that they could be combined before.
* Rename accidental `punctuation.definition.separator.delimiter.php` to `punctuation.separator.delimiter.php`
* Remove what seems to be an unneeded empty-line end match for a different `use` pattern.

### Alternate Designs

None.

### Benefits

* Code cleanup
* Support multiline uses

### Possible Drawbacks

Minor regressions

### Applicable Issues

Fixes #255