### PR TITLE
End complex use statements properly

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -142,7 +142,7 @@
         'beginCaptures':
           '0':
             'name': 'keyword.other.use.php'
-        'end': '(?=;)'
+        'end': '(?<=})|(?=;)'
         'name': 'meta.use.php'
         'patterns': [
           {

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -574,6 +574,7 @@ describe 'PHP grammar', ->
             use A, B {
               B::smallTalk insteadof A;
             }
+            /* comment */
           }
         """
 
@@ -594,6 +595,7 @@ describe 'PHP grammar', ->
         expect(tokens[3][7]).toEqual value: 'A', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'support.class.php']
         expect(tokens[3][8]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'meta.use.body.php', 'punctuation.terminator.expression.php']
         expect(tokens[4][1]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'meta.use.php', 'punctuation.definition.use.end.bracket.curly.php']
+        expect(tokens[5][1]).toEqual value: '/*', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'meta.class.php', 'meta.class.body.php', 'comment.block.php', 'punctuation.definition.comment.php']
 
       it 'tokenizes aliases', ->
         tokens = grammar.tokenizeLines """


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This is a very embarrassing regression caused by #258 that I didn't notice because the specs were testing _only_ the use patterns and not that they were terminated correctly.

### Applicable Issues

Fixes #273