### PR TITLE
Correct __toString capitalisation

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1782,7 +1782,7 @@
           ((?:(?:final|abstract|public|private|protected|static)\\s+)*)
           (function)\\s+
           (?i:
-            (__(?:call|construct|debugInfo|destruct|get|set|isset|unset|tostring|
+            (__(?:call|construct|debugInfo|destruct|get|set|isset|unset|toString|
                   clone|set_state|sleep|wakeup|autoload|invoke|callStatic))
             |([a-zA-Z_\\x{7f}-\\x{ff}][a-zA-Z0-9_\\x{7f}-\\x{ff}]*)
           )


### PR DESCRIPTION
### Description of the Change

Correct the capitalisation of the `__toString` magic method. The other magic methods follow the camelCase convention, so this one should too.

E.g:
![incorrect __toString capitalisation](https://i.imgur.com/tMKWxjK.png)