### PR TITLE
Allow heredocs to end without a semicolon on the same line

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -804,7 +804,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'text.html'
-        'end': '^(\\3)(?=;$)'
+        'end': '^(\\3)(?=;?$)'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -832,7 +832,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'text.xml'
-        'end': '^(\\3)(?=;$)'
+        'end': '^(\\3)(?=;?$)'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -860,7 +860,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.sql'
-        'end': '^(\\3)(?=;$)'
+        'end': '^(\\3)(?=;?$)'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -888,7 +888,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.js'
-        'end': '^(\\3)(?=;$)'
+        'end': '^(\\3)(?=;?$)'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -916,7 +916,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.json'
-        'end': '^(\\3)(?=;$)'
+        'end': '^(\\3)(?=;?$)'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -944,7 +944,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.css'
-        'end': '^(\\3)(?=;$)'
+        'end': '^(\\3)(?=;?$)'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -972,7 +972,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'string.regexp.heredoc.php'
-        'end': '^(\\3)(?=;$)'
+        'end': '^(\\3)(?=;?$)'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1038,7 +1038,7 @@
             'name': 'keyword.operator.heredoc.php'
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
-        'end': '^(\\3)(?=;$)'
+        'end': '^(\\3)(?=;?$)'
         'endCaptures':
           '1':
             'name': 'keyword.operator.heredoc.php'
@@ -1063,7 +1063,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'text.html'
-        'end': '^(\\2)(?=;$)'
+        'end': '^(\\2)(?=;?$)'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1088,7 +1088,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'text.xml'
-        'end': '^(\\2)(?=;$)'
+        'end': '^(\\2)(?=;?$)'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1113,7 +1113,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.sql'
-        'end': '^(\\2)(?=;$)'
+        'end': '^(\\2)(?=;?$)'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1138,7 +1138,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.js'
-        'end': '^(\\2)(?=;$)'
+        'end': '^(\\2)(?=;?$)'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1163,7 +1163,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.json'
-        'end': '^(\\2)(?=;$)'
+        'end': '^(\\2)(?=;?$)'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1188,7 +1188,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.css'
-        'end': '^(\\2)(?=;$)'
+        'end': '^(\\2)(?=;?$)'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1213,7 +1213,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'string.regexp.nowdoc.php'
-        'end': '^(\\2)(?=;$)'
+        'end': '^(\\2)(?=;?$)'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1276,7 +1276,7 @@
             'name': 'keyword.operator.nowdoc.php'
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
-        'end': '^(\\2)(?=;$)'
+        'end': '^(\\2)(?=;?$)'
         'endCaptures':
           '1':
             'name': 'keyword.operator.nowdoc.php'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1641,6 +1641,25 @@ describe 'PHP grammar', ->
     expect(tokens[3][0]).toEqual value: 'HEREDOC', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
     expect(tokens[3][1]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
 
+    tokens = grammar.tokenizeLines """
+      <?php
+      $a = <<<HEREDOC
+      I am a heredoc
+      HEREDOC
+      ;
+    """
+
+    expect(tokens[1][0]).toEqual value: '$', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(tokens[1][1]).toEqual value: 'a', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.php']
+    expect(tokens[1][2]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+    expect(tokens[1][3]).toEqual value: '=', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.assignment.php']
+    expect(tokens[1][4]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
+    expect(tokens[1][5]).toEqual value: '<<<', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'punctuation.definition.string.php']
+    expect(tokens[1][6]).toEqual value: 'HEREDOC', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+    expect(tokens[2][0]).toEqual value: 'I am a heredoc', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php']
+    expect(tokens[3][0]).toEqual value: 'HEREDOC', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+    expect(tokens[4][0]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
+
   it 'does not match incorrect heredoc terminators', ->
     tokens = grammar.tokenizeLines """
       <?php


### PR DESCRIPTION
This enhances #278 

It is not specifically mentioned in manual, but the ending semicolon is simply part of end of the statement. There are cases where heredocs will not end with a semicolon:
```php
<?php
foo(<<<END
abcd
END
);
?>
```