### PR TITLE
Fix issues with TextMate compatibility

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -207,7 +207,7 @@
     'patterns': [
       {
         'begin': '(?i)(?=\\\\?[a-z_0-9]+\\\\)'
-        'end': '(?i)([a-z_][a-z_0-9]*)?(?=[^a-z0-9_\\\\])'
+        'end': '(?i)([a-z_][a-z_0-9]*)?(?![a-z0-9_\\\\])'
         'endCaptures':
           '1':
             'name': 'support.class.php'
@@ -222,7 +222,7 @@
       }
       {
         'begin': '(?=[\\\\a-zA-Z_])'
-        'end': '(?i)([a-z_][a-z_0-9]*)?(?=[^a-z0-9_\\\\])'
+        'end': '(?i)([a-z_][a-z_0-9]*)?(?![a-z0-9_\\\\])'
         'endCaptures':
           '1':
             'name': 'support.class.php'
@@ -2042,13 +2042,13 @@
       }
     ]
   'namespace':
-    'begin': '(?i)(?:(namespace)|[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)?(\\\\)(?=.*?[^a-z0-9_\\x{7f}-\\x{ff}\\\\])'
+    'begin': '(?i)(?:(namespace)|[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)?(\\\\)'
     'beginCaptures':
       '1':
         'name': 'variable.language.namespace.php'
       '2':
         'name': 'punctuation.separator.inheritance.php'
-    'end': '(?i)(?=[a-z0-9_\\x{7f}-\\x{ff}]*[^a-z0-9_\\x{7f}-\\x{ff}\\\\])'
+    'end': '(?i)(?![a-z0-9_\\x{7f}-\\x{ff}]*\\\\)'
     'name': 'support.other.namespace.php'
     'patterns': [
       {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

atom/first-mate#100 tweaked first-mate to be more compliant with the original TextMate grammar implementation.  Rules in language-php that were relying on that extra newline have been rewritten to match even if there is no trailing newline.

### Alternate Designs

Alternative first-mate fix.

### Benefits

language-php will work with first-mate@7.0.8+.  This _might_ fix VSCode as well, though I have no idea how I would go about testing that :).

### Possible Drawbacks

These changes are mostly cosmetic.  The previous end rules were "ensure that there is a next character that is not an identifier", now they're "ensure that the next character is not an identifier".  Subtle difference :).

### Applicable Issues

#221?

/cc @Ingramz
/cc @jens1o @roblourens @aeschli @alexandrudima for VSCode testing