### PR TITLE
Fix namespaces in scope-resolution repository

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2418,7 +2418,7 @@
   'scope-resolution':
     'patterns': [
       {
-        'match': '(?i)\\b([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)(?=\\s*::)'
+        'match': '(?i)((?:\\\\|\\b)[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*(?:\\\\[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)*)(?=\\s*::)'
         'captures':
           '1':
             'patterns': [


### PR DESCRIPTION
WIP

Currently fixes this:
```php
<?php
\a\b\c\d\e::fgh();
```