### PR TITLE
Add .theme file extension

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -14,6 +14,7 @@
   'phpt'
   'phtml'
   'profile'
+  'theme'
 ]
 'firstLineMatch': '''(?x)
   # Hashbang


### PR DESCRIPTION
### Description of the Change

Drupal 8 themes use the .theme extension for PHP files. This change adds that as a valid extension.

### Alternate Designs

None considered.

### Benefits

Proper syntax highlighting for .theme files.

### Possible Drawbacks

None come to mind.
