### PR TITLE
Add support for ternary and null coalescing operators

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2041,6 +2041,15 @@
         'match': ','
         'name': 'punctuation.separator.delimiter.php'
       }
+      {
+        'include': '#ternary_expression'
+      }
+      {
+        'include': '#ternary_shorthand'
+      }
+      {
+        'include': '#null_coalescing'
+      }
     ]
   'namespace':
     'begin': '(?i)(?:(namespace)|[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)?(\\\\)'
@@ -3695,6 +3704,7 @@
       }
     ]
   'variables':
+  
     'patterns': [
       {
         'include': '#var_language'
@@ -3724,3 +3734,32 @@
         ]
       }
     ]
+  
+  'ternary_shorthand':
+    'match': '\\s*(\\?:)\\s*'
+    'captures':
+      '1':
+        'name': 'keyword.operator.ternary.php'
+
+  'ternary_expression':
+    'begin': '(?<!\\?)\\s*(\\?)\\s*(?!:|\\?)'
+    'beginCaptures':
+      '1':
+        'name': 'keyword.operator.ternary.php'
+    'end': '\\s*(:)\\s*'
+    'endCaptures':
+      '1':
+        'name': 'keyword.operator.ternary.php'
+    'patterns': [
+      {
+        'include': '#language'
+      }
+      {
+        'include': '$self'
+      }
+    ]
+  'null_coalescing':
+    'match': '\\s*(\\?\\?)\\s*'
+    'captures':
+      '1':
+        'name': 'keyword.operator.null-coalescing.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -3704,7 +3704,6 @@
       }
     ]
   'variables':
-  
     'patterns': [
       {
         'include': '#var_language'
@@ -3734,13 +3733,9 @@
         ]
       }
     ]
-  
   'ternary_shorthand':
-    'match': '\\s*(\\?:)\\s*'
-    'captures':
-      '1':
-        'name': 'keyword.operator.ternary.php'
-
+    'match': '\\?:'
+    'name': 'keyword.operator.ternary.php'
   'ternary_expression':
     'begin': '(?<!\\?)\\s*(\\?)\\s*(?!:|\\?)'
     'beginCaptures':
@@ -3759,7 +3754,5 @@
       }
     ]
   'null_coalescing':
-    'match': '\\s*(\\?\\?)\\s*'
-    'captures':
-      '1':
-        'name': 'keyword.operator.null-coalescing.php'
+    'match': '\\?\\?'
+    'name': 'keyword.operator.null-coalescing.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -3741,9 +3741,9 @@
     'beginCaptures':
       '1':
         'name': 'keyword.operator.ternary.php'
-    'end': '\\s*(:)\\s*'
+    'end': ':'
     'endCaptures':
-      '1':
+      '0':
         'name': 'keyword.operator.ternary.php'
     'patterns': [
       {

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2042,13 +2042,13 @@
         'name': 'punctuation.separator.delimiter.php'
       }
       {
-        'include': '#ternary_expression'
-      }
-      {
         'include': '#ternary_shorthand'
       }
       {
         'include': '#null_coalescing'
+      }
+      {
+        'include': '#ternary_expression'
       }
     ]
   'namespace':
@@ -3737,9 +3737,9 @@
     'match': '\\?:'
     'name': 'keyword.operator.ternary.php'
   'ternary_expression':
-    'begin': '(?<!\\?)\\s*(\\?)\\s*(?!:|\\?)'
+    'begin': '\\?'
     'beginCaptures':
-      '1':
+      '0':
         'name': 'keyword.operator.ternary.php'
     'end': ':'
     'endCaptures':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -3749,9 +3749,6 @@
       {
         'include': '#language'
       }
-      {
-        'include': '$self'
-      }
     ]
   'null_coalescing':
     'match': '\\?\\?'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -244,7 +244,7 @@ describe 'PHP grammar', ->
           """
           expect(tokens[1][7]).toEqual value: '?:', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.ternary.php']
           expect(tokens[1][11]).toEqual tokens[1][7]
-          expect(tokens[1][7]).toEqual tokens[1][15]
+          expect(tokens[1][15]).toEqual tokens[1][7]
 
         it 'should tokenize a combination of ternaries', ->
           tokens = grammar.tokenizeLines """<?php

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -243,7 +243,7 @@ describe 'PHP grammar', ->
             $foo = false ?: false ?: true ?: false;
           """
           expect(tokens[1][7]).toEqual value: '?:', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.ternary.php']
-          expect(tokens[1][7]).toEqual tokens[1][11]
+          expect(tokens[1][11]).toEqual tokens[1][7]
           expect(tokens[1][7]).toEqual tokens[1][15]
 
         it 'should tokenize a combination of ternaries', ->

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -256,7 +256,6 @@ describe 'PHP grammar', ->
           expect(tokens[2][4]).toEqual value: ':', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.ternary.php']
           expect(tokens[2][8]).toEqual value: '?:', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.ternary.php']
 
-
   it 'should tokenize $this', ->
     tokens = grammar.tokenizeLines "<?php $this"
 

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -209,6 +209,53 @@ describe 'PHP grammar', ->
         expect(tokens[1][4]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
         expect(tokens[1][5]).toEqual value: '2', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'constant.numeric.decimal.php']
         expect(tokens[1][6]).toEqual value: ';', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'punctuation.terminator.expression.php']
+      
+      it 'should tokenize ?? correctly', ->
+        tokens = grammar.tokenizeLines """<?php
+          $foo = $bar ?? 'bar';
+        """
+        expect(tokens[1][8]).toEqual value: '??', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.null-coalescing.php']
+      
+      describe 'ternaries', ->
+        it 'should tokenize ternary expressions', ->
+          tokens = grammar.tokenizeLines """<?php
+            $foo = 1 == 3 ? true : false;
+          """
+          expect(tokens[1][11]).toEqual value: '?', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.ternary.php']
+          expect(tokens[1][15]).toEqual value: ':', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.ternary.php']
+
+          tokens = grammar.tokenizeLines """<?php
+            $foo = 1 == 3
+            ? true
+            : false;
+          """
+          expect(tokens[2][0]).toEqual value: '?', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.ternary.php']
+          expect(tokens[3][0]).toEqual value: ':', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.ternary.php']
+
+          tokens = grammar.tokenizeLines """<?php
+            $foo=1==3?true:false;
+          """
+          expect(tokens[1][6]).toEqual value: '?', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.ternary.php']
+          expect(tokens[1][8]).toEqual value: ':', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.ternary.php']
+        
+        it 'should tokenize shorthand ternaries', ->
+          tokens = grammar.tokenizeLines """<?php
+            $foo = false ?: false ?: true ?: false;
+          """
+          expect(tokens[1][7]).toEqual value: '?:', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.ternary.php']
+          expect(tokens[1][7]).toEqual tokens[1][11]
+          expect(tokens[1][7]).toEqual tokens[1][15]
+
+        it 'should tokenize a combination of ternaries', ->
+          tokens = grammar.tokenizeLines """<?php
+            $foo = false ?: true == 1
+            ? true : false ?: false;
+          """
+          expect(tokens[1][7]).toEqual value: '?:', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.ternary.php']
+          expect(tokens[2][0]).toEqual value: '?', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.ternary.php']
+          expect(tokens[2][4]).toEqual value: ':', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.ternary.php']
+          expect(tokens[2][8]).toEqual value: '?:', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.ternary.php']
+
 
   it 'should tokenize $this', ->
     tokens = grammar.tokenizeLines "<?php $this"


### PR DESCRIPTION
This PR adds scopes for ternaries and the new (as of php7.0) null-coalescing operator.

### Description of the Change

Currently, this is how the above items are scoped:

```php
// ternary expression
  $foo = $bar ? $bar : 'baz';
//            ^text.html.php meta.embedded.block.php source.php
//                   ^text.html.php meta.embedded.block.php source.php

// ternary shorthand
  $foo = $bar ?: 'baz';
//            ^^text.html.php meta.embedded.block.php source.php

// null coalescing operator
  $foo = $bar ?? 'baz';
//            ^^text.html.php meta.embedded.block.php source.php
```

And here's how it is after the changes I made:


```php
// ternary expression
  $foo = $bar ? $bar : 'baz';
//            ^text.html.php meta.embedded.block.php source.php keyword.operator.ternary.php
//                   ^text.html.php meta.embedded.block.php source.php keyword.operator.ternary.php

// ternary shorthand
  $foo = $bar ?: 'baz';
//            ^^text.html.php meta.embedded.block.php source.php keyword.operator.ternary.php

// null coalescing operator
  $foo = $bar ?? 'baz';
//            ^^text.html.php meta.embedded.block.php source.php keyword.operator.null-coalescing.php
```

### Alternate Designs

It would be possible to expand the specificity of the ternary expression scope (e.g. `(expr) : (val_if_true) ? (val_if_false)`) by wrapping the entire expression in `meta.expression.ternary.php` (or something along those lines), but I chose not to do that because it doesn't seem like it would add any value.

### Benefits

- Increased scope specificity.
- Allows theme maintainers to colorize ternary and null coalescing operators the same as the other existing operators.

### Possible Drawbacks

None to my knowledge.