### PR TITLE
Tokenize namespaces when using the scope resolution operator

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2419,7 +2419,7 @@
   'scope-resolution':
     'patterns': [
       {
-        'match': '(?i)\\b([a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)(?=\\s*::)'
+        'match': '(?i)([a-z_\\x{7f}-\\x{ff}\\\\][a-z0-9_\\x{7f}-\\x{ff}\\\\]*)(?=\\s*::)'
         'captures':
           '1':
             'patterns': [

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1067,6 +1067,19 @@ describe 'PHP grammar', ->
       expect(tokens[1][3]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php']
       expect(tokens[1][4]).toEqual value: 'constant', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'constant.other.class.php']
 
+    it 'tokenizes namespaced classes', ->
+      tokens = grammar.tokenizeLines "<?php\n\\One\\Two\\Three::$var"
+
+      expect(tokens[1][0]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[1][1]).toEqual value: 'One', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'support.other.namespace.php']
+      expect(tokens[1][2]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[1][3]).toEqual value: 'Two', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'support.other.namespace.php']
+      expect(tokens[1][4]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[1][5]).toEqual value: 'Three', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'support.class.php']
+      expect(tokens[1][6]).toEqual value: '::', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'keyword.operator.class.php']
+      expect(tokens[1][7]).toEqual value: '$', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.class.php', 'punctuation.definition.variable.php']
+      expect(tokens[1][8]).toEqual value: 'var', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'variable.other.class.php']
+
     it 'tokenizes the special "class" keyword', ->
       tokens = grammar.tokenizeLines "<?php\nobj::class"
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Simply uses the `[a-z_\\x{7f}-\\x{ff}\\\\][a-z0-9_\\x{7f}-\\x{ff}\\\\]*` that is commonly found elsewhere throughout language-php.

### Alternate Designs

None.

### Benefits

Namespaces before a scope resolution operator will be tokenized properly.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #284
Supersedes and closes #281