### PR TITLE
Remove potential zero-width injection pattern

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -41,37 +41,6 @@
   'text.html.php - (meta.embedded | meta.tag), L:text.html.php meta.tag, L:source.js.embedded.html':
     'patterns': [
       {
-        'begin': '(^\\s*)(?=<\\?(?![^?]*\\?>))'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.whitespace.embedded.leading.php'
-        'end': '(?!\\G)(\\s*$\\n)?'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.whitespace.embedded.trailing.php'
-        'patterns': [
-          {
-            'begin': '<\\?(?i:php|=)?'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.begin.php'
-            'contentName': 'source.php'
-            'end': '(\\?)>'
-            'endCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.end.php'
-              '1':
-                'name': 'source.php'
-            'name': 'meta.embedded.block.php'
-            'patterns': [
-              {
-                'include': '#language'
-              }
-            ]
-          }
-        ]
-      }
-      {
         'begin': '<\\?(?i:php|=)?(?![^?]*\\?>)'
         'beginCaptures':
           '0':


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The removed pattern matches and tokenizes leading/trailing whitespace for php blocks.  This is rather useless since Atom already does that.  It was also potentially zero-width if it matched at the start of a line, meaning that Atom would break out of the rule, or worse, enter an infinite loop.

### Alternate Designs

Fix the rule.  This was briefly considered and discarded because well, it's redundant.

### Benefits

Removes an unnecessary rule.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #259

/cc @Ingramz