### PR TITLE
Add tree-sitter PHP grammar

### DIFF
--- a/grammars/tree-sitter-php.cson
+++ b/grammars/tree-sitter-php.cson
@@ -1,0 +1,39 @@
+id: 'php'
+name: 'PHP'
+type: 'tree-sitter'
+parser: 'tree-sitter-php'
+
+comments:
+  start: '#'
+
+fileTypes: [
+  'php'
+  'phpt'
+]
+
+folds: [
+  {
+    start: {type: '{', index: 0},
+    end: {'}', index: -1}
+  }
+  {
+    start: {type: '(', index: 0},
+    end: {')', index: -1}
+  }
+]
+
+scopes:
+  '"echo"': 'support.function'
+  'string': 'string.quoted'
+  'float': 'constant.numeric'
+
+  'function_call_expression > qualified_name': 'entity.name.function'
+  'variable_name': 'variable'
+
+  '"if"': 'keyword.control'
+  '"else"': 'keyword.control'
+  '"elseif"': 'keyword.control'
+  '"endif"': 'keyword.control'
+
+  '"for"': 'keyword.control'
+  '"while"': 'keyword.control'

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "bugs": {
     "url": "https://github.com/atom/language-php/issues"
   },
+  "dependencies": {
+    "tree-sitter-php": "^0.1.1"
+  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }


### PR DESCRIPTION
⚠️  Work in Progress ⚠️ 

This adds an alternative PHP grammar that uses [tree-sitter-php](https://github.com/tree-sitter/tree-sitter-php) for parsing instead of [first-mate](https://github.com/atom/first-mate).

/cc @joshvera 
