### PR TITLE
remove unnecessary space at the end of line

### DIFF
--- a/snippets/language-php.cson
+++ b/snippets/language-php.cson
@@ -56,7 +56,7 @@
     'body': 'elseif (${1:condition}) {\n\t${0:# code...}\n}'
   'for …':
     'prefix': 'for'
-    'body': 'for ($${1:i}=${2:0}; $${1:i} < $3; $${1:i}++) { \n\t${0:# code...}\n}'
+    'body': 'for ($${1:i}=${2:0}; $${1:i} < $3; $${1:i}++) {\n\t${0:# code...}\n}'
   'foreach …':
     'prefix': 'foreach'
     'body': 'foreach ($${1:variable} as $${2:key} ${3:=> $${4:value}}) {\n\t${0:# code...}\n}'


### PR DESCRIPTION
### Description of the Change

remove unnecessary space at the end of the first line of the `for` snippet
