### PR TITLE
Indent lines immediately following switch case keyword

### DIFF
--- a/settings/language-php.cson
+++ b/settings/language-php.cson
@@ -3340,7 +3340,7 @@
     'decreaseIndentPattern': '^(.*\\*/)?\\s*(\\)+)'
 '.source.php:not(.string)':
   'editor':
-    'increaseIndentPattern': '({(?!.+}).*|\\(|\\[|((else)?if|else|for(each)?|while|switch).*:)\\s*(/[/*].*)?$'
+    'increaseIndentPattern': '({(?!.+}).*|\\(|\\[|((else)?if|else|for(each)?|while|switch|case).*:)\\s*(/[/*].*)?$'
     'decreaseIndentPattern': '^(.*\\*/)?\\s*(}|(\\)+([;,]|\\s*{))|(\\]\\)*([;,]|$))|else:|((end(if|for(each)?|while|switch));))'
 '.text.html.php':
   'editor':


### PR DESCRIPTION
### Description of the Change

Add the `case` keyword to `increaseIndentPattern`  to ensure that the line  immediately following switch case keyword is indented properly, see issue #130 .

### Alternate Designs

No alternate designs.

### Benefits

Better code indentation when writing switch statements.

### Possible Drawbacks

Should not be any drawbacks, unless I've introduced some unintended side-effects (not been able to find any side-effects during testing).

### Applicable Issues

#130 
