### PR TITLE
Use // instead of # for PHP comments

### DIFF
--- a/snippets/language-php.cson
+++ b/snippets/language-php.cson
@@ -23,19 +23,19 @@
     'body': '/**\n * ${3:undocumented class variable}\n *\n * @var ${4:string}\n */\n${1:var} $$2;$0'
   'PHPDoc function …':
     'prefix': 'doc_f'
-    'body': '/**\n * ${6:undocumented function summary}\n *\n * ${7:Undocumented function long description}\n *\n * @param ${8:type} ${9:var} ${10:Description}\n * @return ${11:return type}\n */\n${1:public }function ${2:FunctionName}(${3:$${4:value}${5:=\'\'}})\n{\n\t${0:# code...}\n}'
+    'body': '/**\n * ${6:undocumented function summary}\n *\n * ${7:Undocumented function long description}\n *\n * @param ${8:type} ${9:var} ${10:Description}\n * @return ${11:return type}\n */\n${1:public }function ${2:FunctionName}(${3:$${4:value}${5:=\'\'}})\n{\n\t${0:// code...}\n}'
   'Start Docblock':
     'prefix': '/**'
     'body': '/**\n * $0\n */'
   'class …':
     'prefix': 'class'
-    'body': '/**\n * $1\n */\nclass ${2:ClassName} ${3:extends ${4:AnotherClass}}\n{\n\t$5\n\tfunction ${6:__construct}(${7:argument})\n\t{\n\t\t${0:# code...}\n\t}\n}\n'
+    'body': '/**\n * $1\n */\nclass ${2:ClassName} ${3:extends ${4:AnotherClass}}\n{\n\t$5\n\tfunction ${6:__construct}(${7:argument})\n\t{\n\t\t${0:// code...}\n\t}\n}\n'
   'interface …':
     'prefix': 'interface'
-    'body': '/**\n * $1\n */\ninterface ${2:InterfaceName}\n{\n\t${0:# code...}\n}\n'
+    'body': '/**\n * $1\n */\ninterface ${2:InterfaceName}\n{\n\t${0:// code...}\n}\n'
   'trait …':
     'prefix': 'trait'
-    'body': '/**\n * $1\n */\ntrait ${2:TraitName}\n{\n\tfunction ${3:functionName}(${4:argument})\n\t{\n\t\t${5:# code...}\n\t}\n}\n'
+    'body': '/**\n * $1\n */\ntrait ${2:TraitName}\n{\n\tfunction ${3:functionName}(${4:argument})\n\t{\n\t\t${5:// code...}\n\t}\n}\n'
   'define(…, …)':
     'prefix': 'def'
     'body': 'define(\'$1\', ${2:\'$3\'});\n$0'
@@ -44,34 +44,34 @@
     'body': '$1defined(\'$2\')$0'
   'do … while …':
     'prefix': 'do'
-    'body': 'do {\n\t${0:# code...}\n} while (${1:$a <= 10});'
+    'body': 'do {\n\t${0:// code...}\n} while (${1:$a <= 10});'
   'echo "…"':
     'prefix': 'echo'
     'body': 'echo "${1:string}";$0'
   'else …':
     'prefix': 'else'
-    'body': 'else {\n\t${0:# code...}\n}'
+    'body': 'else {\n\t${0:// code...}\n}'
   'elseif …':
     'prefix': 'elseif'
-    'body': 'elseif (${1:condition}) {\n\t${0:# code...}\n}'
+    'body': 'elseif (${1:condition}) {\n\t${0:// code...}\n}'
   'for …':
     'prefix': 'for'
-    'body': 'for ($${1:i}=${2:0}; $${1:i} < $3; $${1:i}++) {\n\t${0:# code...}\n}'
+    'body': 'for ($${1:i}=${2:0}; $${1:i} < $3; $${1:i}++) {\n\t${0:// code...}\n}'
   'foreach …':
     'prefix': 'foreach'
-    'body': 'foreach ($${1:variable} as $${2:key} ${3:=> $${4:value}}) {\n\t${0:# code...}\n}'
+    'body': 'foreach ($${1:variable} as $${2:key} ${3:=> $${4:value}}) {\n\t${0:// code...}\n}'
   'function …':
     'prefix': 'fun'
-    'body': '${1:public }function ${2:FunctionName}(${3:$${4:value}${5:=\'\'}})\n{\n\t${0:# code...}\n}'
+    'body': '${1:public }function ${2:FunctionName}(${3:$${4:value}${5:=\'\'}})\n{\n\t${0:// code...}\n}'
   'anonymous function':
     'prefix': 'f',
-    'body': 'function (${1:$${2:value}${3:=\'\'}}) {\n\t${0:# code...}\n}'
+    'body': 'function (${1:$${2:value}${3:=\'\'}}) {\n\t${0:// code...}\n}'
   'if … else …':
     'prefix': 'ifelse'
-    'body': 'if (${1:condition}) {\n\t${2:# code...}\n} else {\n\t${3:# code...}\n}\n$0'
+    'body': 'if (${1:condition}) {\n\t${2:// code...}\n} else {\n\t${3:// code...}\n}\n$0'
   'if …':
     'prefix': 'if'
-    'body': 'if (${1:condition}) {\n\t${0:# code...}\n}'
+    'body': 'if (${1:condition}) {\n\t${0:// code...}\n}'
   '$… = ( … ) ? … : …':
     'prefix': 'if?'
     'body': '$${1:retVal} = (${2:condition}) ? ${3:a} : ${4:b} ;'
@@ -107,10 +107,10 @@
     'body': 'return true;$0'
   'switch …':
     'prefix': 'switch'
-    'body': 'switch (${1:variable}) {\n\tcase \'${2:value}\':\n\t\t${3:# code...}\n\t\tbreak;\n\t$0\n\tdefault:\n\t\t${4:# code...}\n\t\tbreak;\n}'
+    'body': 'switch (${1:variable}) {\n\tcase \'${2:value}\':\n\t\t${3:// code...}\n\t\tbreak;\n\t$0\n\tdefault:\n\t\t${4:// code...}\n\t\tbreak;\n}'
   'case …':
     'prefix': 'case'
-    'body': 'case \'${1:variable}\':\n\t${0:# code...}\n\tbreak;'
+    'body': 'case \'${1:variable}\':\n\t${0:// code...}\n\tbreak;'
   '$this->…':
     'prefix': 'this'
     'body': '$this->$0'
@@ -125,7 +125,7 @@
     'body': 'try {\n\t$0\n} catch (${1:\\\\Exception $e}) {\n\t$2\n}\n'
   'while …':
     'prefix': 'while'
-    'body': 'while (${1:$a <= 10}) {\n\t${0:# code...}\n}'
+    'body': 'while (${1:$a <= 10}) {\n\t${0:// code...}\n}'
   'var_dump("…")':
     'prefix': 'dump'
     'body': 'var_dump($1);$0'


### PR DESCRIPTION
PSR (_PHP Standards Recommendations_) recommends that inline comments should use `//` and not `#` :smile: 

Refs: [PSRr](https://github.com/php-fig-rectified/fig-rectified-standards/blob/master/PSR-2-R-coding-style-guide-additions.md#commenting-code) and [PSR](https://www.php-fig.org/psr/psr-2/).
