### PR TITLE
Tokenize `yield from`

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -310,8 +310,15 @@
     'include': '#switch_statement'
   }
   {
+    # Special-case `yield from` so its scope isn't `keyword.control.yield from.php`
+    'match': '\\s*\\b(yield\\s+from)\\b'
+    'captures':
+      '1':
+        'name': 'keyword.control.yield-from.php'
+  }
+  {
     'match': '''(?x)
-      \\s*
+      \\s* # FIXME: Removing this causes specs to fail. Investigate.
       \\b(
         break|case|continue|declare|default|die|do|
         else(if)?|end(declare|for(each)?|if|switch|while)|exit|

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1687,7 +1687,7 @@ describe 'PHP grammar', ->
     expect(tokens[12]).toEqual value: 'func', scopes: ['source.php', 'meta.use.php', 'entity.other.alias.php']
     expect(tokens[13]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
-  it 'should tokenize yield correctly', ->
+  it 'tokenizes yield', ->
     {tokens} = grammar.tokenizeLine 'function test() { yield $a; }'
 
     expect(tokens[0]).toEqual value: 'function', scopes: ['source.php', 'meta.function.php', 'storage.type.function.php']
@@ -1705,6 +1705,23 @@ describe 'PHP grammar', ->
     expect(tokens[12]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
     expect(tokens[13]).toEqual value: ' ', scopes: ['source.php']
     expect(tokens[14]).toEqual value: '}', scopes: ['source.php', 'punctuation.definition.end.bracket.curly.php']
+
+  it 'tokenizes `yield from`', ->
+    {tokens} = grammar.tokenizeLine 'function test() { yield from $a; }'
+
+    expect(tokens[8]).toEqual value: 'yield from', scopes: ['source.php', 'keyword.control.yield-from.php']
+    expect(tokens[9]).toEqual value: ' ', scopes: ['source.php']
+    expect(tokens[10]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(tokens[11]).toEqual value: 'a', scopes: ['source.php', 'variable.other.php']
+    expect(tokens[12]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+
+    {tokens} = grammar.tokenizeLine 'function test() { yield      from $a; }'
+
+    expect(tokens[8]).toEqual value: 'yield      from', scopes: ['source.php', 'keyword.control.yield-from.php']
+    expect(tokens[9]).toEqual value: ' ', scopes: ['source.php']
+    expect(tokens[10]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(tokens[11]).toEqual value: 'a', scopes: ['source.php', 'variable.other.php']
+    expect(tokens[12]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
   it 'should tokenize embedded SQL in a string', ->
     waitsForPromise ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

What it says on the tin.

### Alternate Designs

Investigating the conflicting interaction with `default:` and goto syntax and getting that fixed as well.  Out of scope, however.
Maybe a different scope for `from` as well, though it feels more correct for `yield from` to have the same scope.

### Benefits

`yield from` generator support.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #295