### PR TITLE
Use injections for SQL strings

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -48,6 +48,83 @@
         'include': '#php-tag'
       }
     ]
+  'L:source.php string.quoted.single.sql.php source.sql.embedded.php':
+    'patterns': [
+      {
+        'match': '(#)(\\\\\'|[^\'])*(?=\'|$)'
+        'name': 'comment.line.number-sign.sql'
+        'captures':
+          '1':
+            'name': 'punctuation.definition.comment.sql'
+      }
+      {
+        'match': '(--)(\\\\\'|[^\'])*(?=\'|$)'
+        'name': 'comment.line.double-dash.sql'
+        'captures':
+          '1':
+            'name': 'punctuation.definition.comment.sql'
+      }
+      {
+        'match': '\\\\[\\\\\'`"]'
+        'name': 'constant.character.escape.php'
+      }
+      {
+        # Unclosed strings must be captured to avoid them eating the remainder of the PHP script
+        # Sample case: $sql = "SELECT * FROM bar WHERE foo = \'" . $variable . "\'"'
+        'match': '"(?=((\\\\")|[^"\'])*(\'|$))'
+        'name': 'string.quoted.double.unclosed.sql'
+      }
+    ]
+  'L:source.php string.quoted.double.sql.php source.sql.embedded.php':
+    'patterns': [
+      {
+        'match': '(#)(\\\\"|[^"])*(?="|$)'
+        'name': 'comment.line.number-sign.sql'
+        'captures':
+          '1':
+            'name': 'punctuation.definition.comment.sql'
+      }
+      {
+        'match': '(--)(\\\\"|[^"])*(?="|$)'
+        'name': 'comment.line.double-dash.sql'
+        'captures':
+          '1':
+            'name': 'punctuation.definition.comment.sql'
+      }
+      {
+        'match': '\\\\[\\\\\'`"]'
+        'name': 'constant.character.escape.php'
+      }
+      {
+        # Unclosed strings must be captured to avoid them eating the remainder of the PHP script
+        # Sample case: $sql = "SELECT * FROM bar WHERE foo = \'" . $variable . "\'"'
+        'match': '\'(?=((\\\\\')|[^\'"])*("|$))'
+        'name': 'string.quoted.single.unclosed.sql'
+      }
+      {
+        'begin': '\''
+        'end': '\''
+        'name': 'string.quoted.single.sql'
+        'patterns': [
+          {
+            'include': 'source.php#interpolation_double_quoted'
+          }
+        ]
+      }
+      {
+        'begin': '`'
+        'end': '`'
+        'name': 'string.quoted.other.backtick.sql'
+        'patterns': [
+          {
+            'include': 'source.php#interpolation_double_quoted'
+          }
+        ]
+      }
+      {
+        'include': 'source.php#interpolation_double_quoted'
+      }
+    ]
 'patterns': [
   {
     'begin': '\\A#!'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2404,59 +2404,7 @@
     'name': 'string.quoted.double.sql.php'
     'patterns': [
       {
-        'match': '(#)(\\\\"|[^"])*(?="|$)'
-        'name': 'comment.line.number-sign.sql'
-        'captures':
-          '1':
-            'name': 'punctuation.definition.comment.sql'
-      }
-      {
-        'match': '(--)(\\\\"|[^"])*(?="|$)'
-        'name': 'comment.line.double-dash.sql'
-        'captures':
-          '1':
-            'name': 'punctuation.definition.comment.sql'
-      }
-      {
-        'match': '\\\\[\\\\"`\']'
-        'name': 'constant.character.escape.php'
-      }
-      {
-        # Unclosed strings must be captured to avoid them eating the remainder of the PHP script
-        # Sample case: $sql = "SELECT * FROM bar WHERE foo = \'" . $variable . "\'"'
-        'match': '\'(?=((\\\\\')|[^\'"])*("|$))'
-        'name': 'string.quoted.single.unclosed.sql'
-      }
-      {
-        # Unclosed strings must be captured to avoid them eating the remainder of the PHP script
-        # Sample case: $sql = "SELECT * FROM bar WHERE foo = \'" . $variable . "\'"'
-        'match': '`(?=((\\\\`)|[^`"])*("|$))'
-        'name': 'string.quoted.other.backtick.unclosed.sql'
-      }
-      {
-        'begin': '\''
-        'end': '\''
-        'name': 'string.quoted.single.sql'
-        'patterns': [
-          {
-            'include': '#interpolation_double_quoted'
-          }
-        ]
-      }
-      {
-        'begin': '`'
-        'end': '`'
-        'name': 'string.quoted.other.backtick.sql'
-        'patterns': [
-          {
-            'include': '#interpolation_double_quoted'
-          }
-        ]
-      }
-      {
-        'include': '#interpolation_double_quoted'
-      }
-      {
+        # See injections in html.cson for additional patterns
         'include': 'source.sql'
       }
     ]
@@ -2473,36 +2421,7 @@
     'name': 'string.quoted.single.sql.php'
     'patterns': [
       {
-        'match': '(#)(\\\\\'|[^\'])*(?=\'|$)'
-        'name': 'comment.line.number-sign.sql'
-        'captures':
-          '1':
-            'name': 'punctuation.definition.comment.sql'
-      }
-      {
-        'match': '(--)(\\\\\'|[^\'])*(?=\'|$)'
-        'name': 'comment.line.double-dash.sql'
-        'captures':
-          '1':
-            'name': 'punctuation.definition.comment.sql'
-      }
-      {
-        'match': '\\\\[\\\\\'`"]'
-        'name': 'constant.character.escape.php'
-      }
-      {
-        # Unclosed strings must be captured to avoid them eating the remainder of the PHP script
-        # Sample case: $sql = "SELECT * FROM bar WHERE foo = \'" . $variable . "\'"'
-        'match': '`(?=((\\\\`)|[^`\'])*(\'|$))'
-        'name': 'string.quoted.other.backtick.unclosed.sql'
-      }
-      {
-        # Unclosed strings must be captured to avoid them eating the remainder of the PHP script
-        # Sample case: $sql = "SELECT * FROM bar WHERE foo = \'" . $variable . "\'"'
-        'match': '"(?=((\\\\")|[^"\'])*(\'|$))'
-        'name': 'string.quoted.double.unclosed.sql'
-      }
-      {
+        # See injections in html.cson for additional patterns
         'include': 'source.sql'
       }
     ]

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1723,30 +1723,67 @@ describe 'PHP grammar', ->
     expect(tokens[11]).toEqual value: 'a', scopes: ['source.php', 'variable.other.php']
     expect(tokens[12]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
-  it 'should tokenize embedded SQL in a string', ->
-    waitsForPromise ->
-      atom.packages.activatePackage('language-sql')
+  describe 'embedded SQL', ->
+    delimsByScope =
+      'string.quoted.double.sql.php': '"'
+      'string.quoted.single.sql.php': "'"
 
-    runs ->
-      delimsByScope =
-        'string.quoted.double.sql.php': '"'
-        'string.quoted.single.sql.php': "'"
+    beforeEach ->
+      waitsForPromise ->
+        atom.packages.activatePackage('language-sql')
 
+      # Use the HTML wrapper as that's where the SQL injections are
+      runs ->
+        grammar = atom.grammars.grammarForScopeName 'text.html.php'
+
+    it 'tokenizes SQL statements in strngs', ->
       for scope, delim of delimsByScope
-        {tokens} = grammar.tokenizeLine "#{delim}SELECT something#{delim}"
+        {tokens} = grammar.tokenizeLine "<?php #{delim}SELECT something#{delim}"
 
-        expect(tokens[0]).toEqual value: delim, scopes: ['source.php', scope, 'punctuation.definition.string.begin.php']
-        expect(tokens[1]).toEqual value: 'SELECT', scopes: ['source.php', scope, 'source.sql.embedded.php', 'keyword.other.DML.sql']
-        expect(tokens[2]).toEqual value: ' something', scopes: ['source.php', scope, 'source.sql.embedded.php']
-        expect(tokens[3]).toEqual value: delim, scopes: ['source.php', scope, 'punctuation.definition.string.end.php']
+        expect(tokens[2]).toEqual value: delim, scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', scope, 'punctuation.definition.string.begin.php']
+        expect(tokens[3]).toEqual value: 'SELECT', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', scope, 'source.sql.embedded.php', 'keyword.other.DML.sql']
+        expect(tokens[4]).toEqual value: ' something', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', scope, 'source.sql.embedded.php']
+        expect(tokens[5]).toEqual value: delim, scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', scope, 'punctuation.definition.string.end.php']
 
+    it 'stops line comments when a quote is reached', ->
+      for scope, delim of delimsByScope
         lines = grammar.tokenizeLines """
+          <?php
           #{delim}SELECT something
           -- uh oh a comment SELECT#{delim}
         """
-        expect(lines[1][0]).toEqual value: '--', scopes: ['source.php', scope, 'source.sql.embedded.php', 'comment.line.double-dash.sql', 'punctuation.definition.comment.sql']
-        expect(lines[1][1]).toEqual value: ' uh oh a comment SELECT', scopes: ['source.php', scope, 'source.sql.embedded.php', 'comment.line.double-dash.sql']
-        expect(lines[1][2]).toEqual value: delim, scopes: ['source.php', scope, 'punctuation.definition.string.end.php']
+        expect(lines[2][0]).toEqual value: '--', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', scope, 'source.sql.embedded.php', 'comment.line.double-dash.sql', 'punctuation.definition.comment.sql']
+        expect(lines[2][1]).toEqual value: ' uh oh a comment SELECT', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', scope, 'source.sql.embedded.php', 'comment.line.double-dash.sql']
+        expect(lines[2][2]).toEqual value: delim, scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', scope, 'punctuation.definition.string.end.php']
+
+    it 'matches escape sequences in parentheses', ->
+      {tokens} = grammar.tokenizeLine "<?php 'SELECT CONCAT(\\'\"\\', TRIM(cr.code)) as code'"
+
+      expect(tokens[2]).toEqual value: "'", scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.single.sql.php', 'punctuation.definition.string.begin.php']
+      expect(tokens[5]).toEqual value: '(', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'punctuation.definition.section.bracket.round.begin.sql']
+      expect(tokens[6]).toEqual value: "\\'", scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'constant.character.escape.php']
+      expect(tokens[7]).toEqual value: '"', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'string.quoted.double.unclosed.sql']
+      expect(tokens[8]).toEqual value: "\\'", scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'constant.character.escape.php']
+      expect(tokens[9]).toEqual value: ',', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'punctuation.separator.comma.sql']
+      expect(tokens[10]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php']
+      expect(tokens[11]).toEqual value: 'TRIM', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'support.function.string.sql']
+      expect(tokens[17]).toEqual value: ')', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'punctuation.definition.section.bracket.round.end.sql']
+      expect(tokens[19]).toEqual value: 'as', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'keyword.other.alias.sql']
+      expect(tokens[21]).toEqual value: "'", scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.single.sql.php', 'punctuation.definition.string.end.php']
+
+      {tokens} = grammar.tokenizeLine '<?php "SELECT CONCAT(\\"\'\\", TRIM(cr.code)) as code"'
+
+      expect(tokens[2]).toEqual value: '"', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'punctuation.definition.string.begin.php']
+      expect(tokens[5]).toEqual value: '(', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'punctuation.definition.section.bracket.round.begin.sql']
+      expect(tokens[6]).toEqual value: '\\"', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'constant.character.escape.php']
+      expect(tokens[7]).toEqual value: "'", scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.quoted.single.unclosed.sql']
+      expect(tokens[8]).toEqual value: '\\"', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'constant.character.escape.php']
+      expect(tokens[9]).toEqual value: ',', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'punctuation.separator.comma.sql']
+      expect(tokens[10]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php']
+      expect(tokens[11]).toEqual value: 'TRIM', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'support.function.string.sql']
+      expect(tokens[17]).toEqual value: ')', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'punctuation.definition.section.bracket.round.end.sql']
+      expect(tokens[19]).toEqual value: 'as', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'keyword.other.alias.sql']
+      expect(tokens[21]).toEqual value: '"', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'punctuation.definition.string.end.php']
 
   it 'should tokenize single quoted string regex escape characters correctly', ->
     {tokens} = grammar.tokenizeLine "'/[\\\\\\\\]/';"

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1736,7 +1736,7 @@ describe 'PHP grammar', ->
       runs ->
         grammar = atom.grammars.grammarForScopeName 'text.html.php'
 
-    it 'tokenizes SQL statements in strngs', ->
+    it 'tokenizes SQL statements in strings', ->
       for scope, delim of delimsByScope
         {tokens} = grammar.tokenizeLine "<?php #{delim}SELECT something#{delim}"
 
@@ -1784,6 +1784,19 @@ describe 'PHP grammar', ->
       expect(tokens[17]).toEqual value: ')', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'punctuation.definition.section.bracket.round.end.sql']
       expect(tokens[19]).toEqual value: 'as', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'keyword.other.alias.sql']
       expect(tokens[21]).toEqual value: '"', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'punctuation.definition.string.end.php']
+
+    # TODO: Remove version guard when Atom 1.29 reaches stable
+    if parseFloat(atom.getVersion()) >= 1.29
+      it 'tokenizes interpolation in SQL strings', ->
+        {tokens} = grammar.tokenizeLine '<?php "SELECT \\007 {$bond}"'
+
+        expect(tokens[2]).toEqual value: '"', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'punctuation.definition.string.begin.php']
+        expect(tokens[5]).toEqual value: '\\007', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'constant.character.escape.octal.php']
+        expect(tokens[7]).toEqual value: '{', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'punctuation.definition.variable.php']
+        expect(tokens[8]).toEqual value: '$', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[9]).toEqual value: 'bond', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'variable.other.php']
+        expect(tokens[10]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'punctuation.definition.variable.php']
+        expect(tokens[11]).toEqual value: '"', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'punctuation.definition.string.end.php']
 
   it 'should tokenize single quoted string regex escape characters correctly', ->
     {tokens} = grammar.tokenizeLine "'/[\\\\\\\\]/';"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Now that language-sql has begin/end matches, injections are needed so that the PHP patterns are matched inside the begin/end ones as well.  Unfortunately, due to some annoyances with how injections work, I had to place the injections inside of the wrapper `html.cson` rather than `php.cson`, which would make much more sense.

~~I am also having trouble getting interpolation to work properly.  Seems like it's not picking up source.php correctly, which is discouraging...~~

### Alternate Designs

I would love to hear proposals for alternate designs.

### Benefits

Embedded SQL strings should no longer have the chance of ruining syntax highlighting for the rest of the file.

### Possible Drawbacks

Grammar becomes harder to parse due to the injections being in a separate file.

### Applicable Issues

Fixes #321