### PR TITLE
Recognize interpolation in SQL strings in embedded SQL

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -68,12 +68,6 @@
         'match': '\\\\[\\\\\'`"]'
         'name': 'constant.character.escape.php'
       }
-      {
-        # Unclosed strings must be captured to avoid them eating the remainder of the PHP script
-        # Sample case: $sql = "SELECT * FROM bar WHERE foo = \'" . $variable . "\'"'
-        'match': '"(?=((\\\\")|[^"\'])*(\'|$))'
-        'name': 'string.quoted.double.unclosed.sql'
-      }
     ]
   'L:source.php string.quoted.double.sql.php source.sql.embedded.php':
     'patterns': [
@@ -96,30 +90,36 @@
         'name': 'constant.character.escape.php'
       }
       {
-        # Unclosed strings must be captured to avoid them eating the remainder of the PHP script
-        # Sample case: $sql = "SELECT * FROM bar WHERE foo = \'" . $variable . "\'"'
-        'match': '\'(?=((\\\\\')|[^\'"])*("|$))'
-        'name': 'string.quoted.single.unclosed.sql'
-      }
-      {
-        'begin': '\''
-        'end': '\''
+        # language-sql has single-line rules for strings that prevent injections from working; override them
+        'match': '(\')([^\'\\\\]*)(\')'
         'name': 'string.quoted.single.sql'
-        'patterns': [
-          {
-            'include': 'source.php#interpolation_double_quoted'
-          }
-        ]
+        'captures':
+          '1':
+            'name': 'punctuation.definition.string.begin.sql'
+          '2':
+            'patterns': [
+              {
+                'include': 'source.php#interpolation_double_quoted'
+              }
+            ]
+          '3':
+            'name': 'punctuation.definition.string.end.sql'
       }
       {
-        'begin': '`'
-        'end': '`'
+        # language-sql has single-line rules for strings that prevent injections from working; override them
+        'match': '(`)([^`\\\\]*)(`)'
         'name': 'string.quoted.other.backtick.sql'
-        'patterns': [
-          {
-            'include': 'source.php#interpolation_double_quoted'
-          }
-        ]
+        'captures':
+          '1':
+            'name': 'punctuation.definition.string.begin.sql'
+          '2':
+            'patterns': [
+              {
+                'include': 'source.php#interpolation_double_quoted'
+              }
+            ]
+          '3':
+            'name': 'punctuation.definition.string.end.sql'
       }
       {
         'include': 'source.php#interpolation_double_quoted'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -68,6 +68,12 @@
         'match': '\\\\[\\\\\'`"]'
         'name': 'constant.character.escape.php'
       }
+      {
+        # Unclosed strings must be captured to avoid them eating the remainder of the PHP script
+        # Sample case: $sql = 'SELECT CONCAT(\'"\', TRIM(cr.code)) as code'
+        'match': '"(?=((\\\\")|[^"\'])*(\'|$))'
+        'name': 'string.quoted.double.unclosed.sql'
+      }
     ]
   'L:source.php string.quoted.double.sql.php source.sql.embedded.php':
     'patterns': [
@@ -120,6 +126,12 @@
             ]
           '3':
             'name': 'punctuation.definition.string.end.sql'
+      }
+      {
+        # Unclosed strings must be captured to avoid them eating the remainder of the PHP script
+        # Sample case: $sql = 'SELECT CONCAT(\'"\', TRIM(cr.code)) as code'
+        'match': '\'(?=((\\\\\')|[^\'"])*("|$))'
+        'name': 'string.quoted.single.unclosed.sql'
       }
       {
         'include': 'source.php#interpolation_double_quoted'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1890,8 +1890,8 @@
       }
     ]
   'interpolation':
-    # http://www.php.net/manual/en/language.types.string.php$self.types.string.parsing
-    # http://www.php.net/manual/en/language.types.string.php$self.types.string.syntax.double
+    # http://www.php.net/manual/en/language.types.string.php#language.types.string.parsing
+    # http://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.double
     'patterns': [
       {
         'match': '\\\\[0-7]{1,3}'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1787,7 +1787,7 @@ describe 'PHP grammar', ->
 
     # TODO: Remove version guard when Atom 1.29 reaches stable
     if parseFloat(atom.getVersion()) >= 1.29
-      it 'tokenizes interpolation in SQL strings', ->
+      it 'tokenizes interpolation', ->
         {tokens} = grammar.tokenizeLine '<?php "SELECT \\007 {$bond}"'
 
         expect(tokens[2]).toEqual value: '"', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'punctuation.definition.string.begin.php']
@@ -1797,6 +1797,28 @@ describe 'PHP grammar', ->
         expect(tokens[9]).toEqual value: 'bond', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'variable.other.php']
         expect(tokens[10]).toEqual value: '}', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'punctuation.definition.variable.php']
         expect(tokens[11]).toEqual value: '"', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'punctuation.definition.string.end.php']
+
+      it 'tokenizes interpolation in SQL strings', ->
+        {tokens} = grammar.tokenizeLine '<?php "INSERT INTO mytable(field1, field2) VALUES (\'".$val1."\', `".$val2."`)"'
+
+        expect(tokens[2]).toEqual value: '"', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'punctuation.definition.string.begin.php']
+        expect(tokens[13]).toEqual value: '(', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'punctuation.definition.section.bracket.round.begin.sql']
+        expect(tokens[14]).toEqual value: "'", scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.quoted.single.sql', 'punctuation.definition.string.begin.sql']
+        expect(tokens[15]).toEqual value: '".', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.quoted.single.sql']
+        expect(tokens[16]).toEqual value: '$', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.quoted.single.sql', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[17]).toEqual value: 'val1', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.quoted.single.sql', 'variable.other.php']
+        expect(tokens[18]).toEqual value: '."', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.quoted.single.sql']
+        expect(tokens[19]).toEqual value: "'", scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.quoted.single.sql', 'punctuation.definition.string.end.sql']
+        expect(tokens[20]).toEqual value: ',', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'punctuation.separator.comma.sql']
+        expect(tokens[21]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php']
+        expect(tokens[22]).toEqual value: '`', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'punctuation.definition.string.begin.sql']
+        expect(tokens[23]).toEqual value: '".', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql']
+        expect(tokens[24]).toEqual value: '$', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[25]).toEqual value: 'val2', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'variable.other.php']
+        expect(tokens[26]).toEqual value: '."', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql']
+        expect(tokens[27]).toEqual value: '`', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'punctuation.definition.string.end.sql']
+        expect(tokens[28]).toEqual value: ')', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'punctuation.definition.section.bracket.round.end.sql']
+        expect(tokens[29]).toEqual value: '"', scopes: ['text.html.php', 'meta.embedded.block.php', 'source.php', 'string.quoted.double.sql.php', 'punctuation.definition.string.end.php']
 
   it 'should tokenize single quoted string regex escape characters correctly', ->
     {tokens} = grammar.tokenizeLine "'/[\\\\\\\\]/';"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

language-sql has match patterns for single-line strings that prevent interpolation injections from matching.  To get around this, override those match patterns with our own that recognize interpolations.

### Alternate Designs

Make injections work in matches.  This would get really hairy, really quickly.

### Benefits

Interpolation in single-line strings.

### Possible Drawbacks

I don't really see any.

### Applicable Issues

Fixes #331