### PR TITLE
Fix PHP tags being injected into PHP source code

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -42,7 +42,7 @@
 'foldingStartMarker': '(/\\*|\\{\\s*$|<<<HTML)'
 'foldingStopMarker': '(\\*/|^\\s*\\}|^HTML;)'
 'injections':
-  'text.html.php - (meta.embedded | meta.tag), L:text.html.php meta.tag, L:source.js.embedded.html':
+  'text.html.php - (meta.embedded | meta.tag), L:((text.html.php meta.tag) - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.js.embedded.html - (meta.embedded.block.php | meta.embedded.line.php))':
     'patterns': [
       {
         'include': '#php-tag'


### PR DESCRIPTION
### Description of the Change

This pull request excludes PHP tag scopes `meta.embedded.block.php` and `meta.embedded.line.php` from injections when PHP code is used within script tags or inline HTML similarly to the base case that does not involve HTML.

### Alternate Designs

N/A

### Benefits

N/A

### Possible Drawbacks

N/A

### Applicable Issues

Fixes #326 
