### PR TITLE
Add self, static and parent to variable.language.php

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2329,7 +2329,12 @@
             'patterns': [
               {
                 'match': '\\b(self|static|parent)\\b'
-                'name': 'storage.type.php'
+                'name': 'storage.type.php',
+								"captures": {
+                  "1": {
+                    "name": "variable.language.php"
+                  }
+                }
               }
               {
                 'include': '#class-name'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2330,9 +2330,9 @@
               {
                 'match': '\\b(self|static|parent)\\b'
                 'name': 'storage.type.php',
-								"captures": {
-                  "1": {
-                    "name": "variable.language.php"
+                'captures': {
+                  '1': {
+                    'name': 'variable.language.php'
                   }
                 }
               }


### PR DESCRIPTION
### Description of the Change

Usually `$this` and the other in-class variables (`self`, `static` and `parent`) in PHP are of the same color in most of the editors. To make it different from functions (storage.type), the change is useful. It won't affect any existing behavior.

### Benefits

It will allow the color themes differentiate these keywords from other `storage.type(s)`.

### Possible Drawbacks

Some color themes may have some effect on the token color due to this change in scope rules.
