### PR TITLE
Add missing PHP code mixing within <style> tags

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -42,7 +42,7 @@
 'foldingStartMarker': '(/\\*|\\{\\s*$|<<<HTML)'
 'foldingStopMarker': '(\\*/|^\\s*\\}|^HTML;)'
 'injections':
-  'text.html.php - (meta.embedded | meta.tag), L:((text.html.php meta.tag) - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.js.embedded.html - (meta.embedded.block.php | meta.embedded.line.php))':
+  'text.html.php - (meta.embedded | meta.tag), L:((text.html.php meta.tag) - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.js.embedded.html - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.css - (meta.embedded.block.php | meta.embedded.line.php))':
     'patterns': [
       {
         'include': '#php-tag'

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -109,6 +109,34 @@ describe 'PHP in HTML', ->
       expect(lines[7][1]).toEqual value: 'script', scopes: ['text.html.php', 'meta.tag.script.html', 'entity.name.tag.script.html']
       expect(lines[7][2]).toEqual value: '>', scopes: ['text.html.php', 'meta.tag.script.html', 'punctuation.definition.tag.html']
 
+    it 'does not tokenize PHP tag syntax within PHP syntax itself inside HTML style tags (regression)', ->
+      lines = grammar.tokenizeLines '''
+        <style>
+        <?php
+          /*
+            ?>
+            <?php
+          */
+        ?>
+        </style>
+      '''
+
+      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.php', 'meta.tag.style.html', 'punctuation.definition.tag.html']
+      expect(lines[0][1]).toEqual value: 'style', scopes: ['text.html.php', 'meta.tag.style.html', 'entity.name.tag.style.html']
+      expect(lines[0][2]).toEqual value: '>', scopes: ['text.html.php', 'meta.tag.style.html', 'punctuation.definition.tag.html']
+      expect(lines[1][0]).toEqual value: '<?php', scopes: ['text.html.php', 'meta.tag.style.html', 'source.css.embedded.html', 'meta.embedded.block.php', 'punctuation.section.embedded.begin.php']
+      expect(lines[2][0]).toEqual value: '  ', scopes: ['text.html.php', 'meta.tag.style.html', 'source.css.embedded.html', 'meta.embedded.block.php', 'source.php']
+      expect(lines[2][1]).toEqual value: '/*', scopes: ['text.html.php', 'meta.tag.style.html', 'source.css.embedded.html', 'meta.embedded.block.php', 'source.php', 'comment.block.php', 'punctuation.definition.comment.php']
+      expect(lines[3][0]).toEqual value: '    ?>', scopes: ['text.html.php', 'meta.tag.style.html', 'source.css.embedded.html', 'meta.embedded.block.php', 'source.php', 'comment.block.php']
+      expect(lines[4][0]).toEqual value: '    <?php', scopes: ['text.html.php', 'meta.tag.style.html', 'source.css.embedded.html', 'meta.embedded.block.php', 'source.php', 'comment.block.php']
+      expect(lines[5][0]).toEqual value: '  ', scopes: ['text.html.php', 'meta.tag.style.html', 'source.css.embedded.html', 'meta.embedded.block.php', 'source.php', 'comment.block.php']
+      expect(lines[5][1]).toEqual value: '*/', scopes: ['text.html.php', 'meta.tag.style.html', 'source.css.embedded.html', 'meta.embedded.block.php', 'source.php', 'comment.block.php', 'punctuation.definition.comment.php']
+      expect(lines[6][0]).toEqual value: '?', scopes: ['text.html.php', 'meta.tag.style.html', 'source.css.embedded.html', 'meta.embedded.block.php', 'punctuation.section.embedded.end.php', 'source.php']
+      expect(lines[6][1]).toEqual value: '>', scopes: ['text.html.php', 'meta.tag.style.html', 'source.css.embedded.html', 'meta.embedded.block.php', 'punctuation.section.embedded.end.php']
+      expect(lines[7][0]).toEqual value: '</', scopes: ['text.html.php', 'meta.tag.style.html', 'punctuation.definition.tag.html']
+      expect(lines[7][1]).toEqual value: 'style', scopes: ['text.html.php', 'meta.tag.style.html', 'entity.name.tag.style.html']
+      expect(lines[7][2]).toEqual value: '>', scopes: ['text.html.php', 'meta.tag.style.html', 'punctuation.definition.tag.html']
+
     it 'does not tokenize PHP tag syntax within PHP syntax itself inside HTML attributes (regression)', ->
       {tokens} = grammar.tokenizeLine '<img src="<?php /* ?> <?php */ ?>" />'
 


### PR DESCRIPTION
### Description of the Change
CSS one of the required languages that can be mixed within PHP files along with HTML and Javascript, needed to embed specific code based on conditions.

HTML mixing `<div><?php echo $title ?></div>` and JS mixing `<script type="text/javascript"><?php echo $var ?></script>` inline or within blocks have been already implemented long time ago. But CSS support for `<style>` tags still missing.

CSS mixing is required only for php type files (php5, phtml, etc.) and only within `<style>` tags.
Mixing inside .css files, as well as .html and .js, is not allowed.

### Alternate Designs
The only way to mixing css styles without breaking syntax highlighting is to duplicate whole `<style>` tags with different content or force to use external stylesheets, which is not always applicable when using templates, MVC pattern, when avoiding render blocking, etc.

### Benefits
PHP parser not depends on IDE or any editor syntax highlighting. But this pull request adds support for correct syntax recognizing inside Atom, VS Code and many other editors that uses Atom's grammar, which needed for syntax linters, intellisense, code snippets and suggestions to work as well inside mixing content.

### Possible Drawbacks
VS Code, for which this pull request was made initially, uses modified grammar rules.
VS Code rule `L:(source.css - (meta.embedded.block.php | meta.embedded.line.php))` can be loaded from /php/ folder extension, but Atom rules may require modifications to work only within php files. This may be `source.css.embedded.html` if there is exists one.

### Applicable Issues
None.

### Example
```
<style type="text/css">
<?php if ( empty( $comments ) ) { ?>
.comments {
    display: block;
}
<?php } ?>
</style>
```