### PR TITLE
begin -> match

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2750,7 +2750,7 @@
         'name': 'support.function.com.php'
       }
       {
-        'begin': '(?i)\\b(isset|unset|eval|empty|list)\\b'
+        'match': '(?i)\\b(isset|unset|eval|empty|list)\\b'
         'name': 'support.function.construct.php'
       }
       {


### PR DESCRIPTION
### Description of the Change

As discussed in https://github.com/atom/language-php/issues/351, this rule uses `begin` but it would be less confusing and more consistent with the other rules if it used `match`. This does not change the behavior of the rule.

### Alternate Designs

N/A

### Benefits

Code clarity and consistency

### Possible Drawbacks

None

### Applicable Issues

https://github.com/atom/language-php/issues/351
