### PR TITLE
Fixing syntax highlighting issue for flexible HEREDOC and NOWDOC in PHP 7.3

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1393,7 +1393,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'text.html'
-        'end': '^(\\3)(?=;?$)'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1421,7 +1421,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'text.xml'
-        'end': '^(\\3)(?=;?$)'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1449,7 +1449,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.sql'
-        'end': '^(\\3)(?=;?$)'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1477,7 +1477,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.js'
-        'end': '^(\\3)(?=;?$)'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1505,7 +1505,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.json'
-        'end': '^(\\3)(?=;?$)'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1533,7 +1533,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.css'
-        'end': '^(\\3)(?=;?$)'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1561,7 +1561,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'string.regexp.heredoc.php'
-        'end': '^(\\3)(?=;?$)'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1627,7 +1627,7 @@
             'name': 'keyword.operator.heredoc.php'
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
-        'end': '^(\\3)(?=;?$)'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '1':
             'name': 'keyword.operator.heredoc.php'
@@ -1652,7 +1652,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'text.html'
-        'end': '^(\\2)(?=;?$)'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1677,7 +1677,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'text.xml'
-        'end': '^(\\2)(?=;?$)'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1702,7 +1702,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.sql'
-        'end': '^(\\2)(?=;?$)'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1727,7 +1727,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.js'
-        'end': '^(\\2)(?=;?$)'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1752,7 +1752,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.json'
-        'end': '^(\\2)(?=;?$)'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1777,7 +1777,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.css'
-        'end': '^(\\2)(?=;?$)'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1802,7 +1802,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'string.regexp.nowdoc.php'
-        'end': '^(\\2)(?=;?$)'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1865,7 +1865,7 @@
             'name': 'keyword.operator.nowdoc.php'
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
-        'end': '^(\\2)(?=;?$)'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
         'endCaptures':
           '1':
             'name': 'keyword.operator.nowdoc.php'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1863,6 +1863,28 @@ describe 'PHP grammar', ->
     expect(tokens[4]).toEqual value: '\'', scopes: ['source.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
     expect(tokens[5]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
+  it 'should tokenize heredoc in a function call correctly', ->
+    lines = grammar.tokenizeLines  '''
+    foo(
+      <<<HEREDOC
+      This is just a cool test.
+      HEREDOC,
+      $bar
+    );
+    '''
+
+    expect(lines[0][0]).toEqual value: 'foo', scopes: ['source.php', 'meta.function-call.php', 'entity.name.function.php']
+    expect(lines[0][1]).toEqual value: '(', scopes: ['source.php', 'meta.function-call.php', 'punctuation.definition.arguments.begin.bracket.round.php']
+    expect(lines[1][1]).toEqual value: '<<<', scopes: ['source.php', 'meta.function-call.php', 'string.unquoted.heredoc.php', 'punctuation.definition.string.php']
+    expect(lines[1][2]).toEqual value: 'HEREDOC', scopes: ['source.php', 'meta.function-call.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+    expect(lines[2][0]).toEqual value: '  This is just a cool test.', scopes: ['source.php', 'meta.function-call.php', 'string.unquoted.heredoc.php']
+    expect(lines[3][1]).toEqual value: 'HEREDOC', scopes: ['source.php', 'meta.function-call.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+    expect(lines[3][2]).toEqual value: ',', scopes: ['source.php', 'meta.function-call.php', 'punctuation.separator.delimiter.php']
+    expect(lines[4][1]).toEqual value: '$', scopes: ['source.php', 'meta.function-call.php', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(lines[4][2]).toEqual value: 'bar', scopes: ['source.php', 'meta.function-call.php', 'variable.other.php']
+    expect(lines[5][0]).toEqual value: ')', scopes: ['source.php', 'meta.function-call.php', 'punctuation.definition.arguments.end.bracket.round.php']
+    expect(lines[5][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+
   it 'should tokenize a simple heredoc correctly', ->
     lines = grammar.tokenizeLines '''
       $a = <<<HEREDOC
@@ -1899,20 +1921,42 @@ describe 'PHP grammar', ->
     expect(lines[2][0]).toEqual value: 'HEREDOC', scopes: ['source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
     expect(lines[3][0]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
-  it 'does not match incorrect heredoc terminators', ->
     lines = grammar.tokenizeLines '''
       $a = <<<HEREDOC
       I am a heredoc
       HEREDOC ;
     '''
-    expect(lines[2][0]).toEqual value: 'HEREDOC ;', scopes: ['source.php', 'string.unquoted.heredoc.php']
+
+    expect(lines[0][0]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(lines[0][1]).toEqual value: 'a', scopes: ['source.php', 'variable.other.php']
+    expect(lines[0][2]).toEqual value: ' ', scopes: ['source.php']
+    expect(lines[0][3]).toEqual value: '=', scopes: ['source.php', 'keyword.operator.assignment.php']
+    expect(lines[0][4]).toEqual value: ' ', scopes: ['source.php']
+    expect(lines[0][5]).toEqual value: '<<<', scopes: ['source.php', 'string.unquoted.heredoc.php', 'punctuation.definition.string.php']
+    expect(lines[0][6]).toEqual value: 'HEREDOC', scopes: ['source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+    expect(lines[1][0]).toEqual value: 'I am a heredoc', scopes: ['source.php', 'string.unquoted.heredoc.php']
+    expect(lines[2][0]).toEqual value: 'HEREDOC', scopes: ['source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+    expect(lines[2][1]).toEqual value: ' ', scopes: ['source.php']
+    expect(lines[2][2]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
     lines = grammar.tokenizeLines '''
       $a = <<<HEREDOC
       I am a heredoc
       HEREDOC; // comment
     '''
-    expect(lines[2][0]).toEqual value: 'HEREDOC; // comment', scopes: ['source.php', 'string.unquoted.heredoc.php']
+    
+    expect(lines[0][0]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(lines[0][1]).toEqual value: 'a', scopes: ['source.php', 'variable.other.php']
+    expect(lines[0][2]).toEqual value: ' ', scopes: ['source.php']
+    expect(lines[0][3]).toEqual value: '=', scopes: ['source.php', 'keyword.operator.assignment.php']
+    expect(lines[0][4]).toEqual value: ' ', scopes: ['source.php']
+    expect(lines[0][5]).toEqual value: '<<<', scopes: ['source.php', 'string.unquoted.heredoc.php', 'punctuation.definition.string.php']
+    expect(lines[0][6]).toEqual value: 'HEREDOC', scopes: ['source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+    expect(lines[1][0]).toEqual value: 'I am a heredoc', scopes: ['source.php', 'string.unquoted.heredoc.php']
+    expect(lines[2][0]).toEqual value: 'HEREDOC', scopes: ['source.php', 'string.unquoted.heredoc.php', 'keyword.operator.heredoc.php']
+    expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+    expect(lines[2][2]).toEqual value: ' ', scopes: ['source.php']
+    expect(lines[2][3]).toEqual value: '//', scopes: ['source.php', 'comment.line.double-slash.php', 'punctuation.definition.comment.php']
 
   it 'should tokenize a longer heredoc correctly', ->
     lines = grammar.tokenizeLines '''


### PR DESCRIPTION
[The previous pull request](https://github.com/atom/language-php/pull/357) got closed by my mistake as I was trying to force pushing and I couldn't make it open. I'm sorry for that 😞. I'm new to GitHub.

Thanks to @wecc, @Ingramz. It is now ready to be merged.

### Description of the Change

As already reported in [346](https://github.com/atom/language-php/issues/346) flexible HEREDOC and NOWDOC as introduced in PHP 7.3 will cause syntax highlighting to be failed.

### Benefits
We can have syntax highlighting to be working even if we use flexible HEREDOC and NOWDOC.

### Possible Drawbacks
The only change which I made was the regex of HEREDOC and NOWDOC endings, so I do not think any particular issue it might cause. As it is most likely how PHP mechanism will detect the end of these two blocks.

So :
```php
$example = foo(
  <<<HEREDOC
  This is just a cool test.
  HEREDOC,
  $bar
);
$rest_of_the_code = 'hello';
```
Should now have syntax highlighting to be worked properly.
