### PR TITLE
Fix functions returning references and return type declarations

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -395,7 +395,7 @@
     'beginCaptures':
       '1':
         'name': 'storage.type.function.php'
-    'end': '(?={)'
+    'end': '(?=\\s*{)'
     'name': 'meta.function.closure.php'
     'patterns': [
       {
@@ -442,7 +442,7 @@
         ]
       }
       {
-        'match': '(:)\\s*(\\?)?\\s*((?:\\\\?[a-zA-Z_\\x{7f}-\\x{7fffffff}][a-zA-Z0-9_\\x{7f}-\\x{7fffffff}]*)+)\\s*'
+        'match': '(:)\\s*(\\?)?\\s*((?:\\\\?[a-zA-Z_\\x{7f}-\\x{7fffffff}][a-zA-Z0-9_\\x{7f}-\\x{7fffffff}]*)+)'
         'captures':
           '1':
             'name': 'keyword.operator.return-value.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -441,6 +441,16 @@
           }
         ]
       }
+      {
+        'match': '(:)\\s*(\\?)?\\s*((?:\\\\?[a-zA-Z_\\x{7f}-\\x{7fffffff}][a-zA-Z0-9_\\x{7f}-\\x{7fffffff}]*)+)\\s*'
+        'captures':
+          '1':
+            'name': 'keyword.operator.return-value.php'
+          '2':
+            'name': 'keyword.operator.nullable-type.php'
+          '3':
+            'name': 'storage.type.php'
+      }
     ]
   }
   {
@@ -473,7 +483,7 @@
       '6':
         'name': 'punctuation.definition.parameters.begin.bracket.round.php'
     'contentName': 'meta.function.parameters.php'
-    'end': '(\\))(?:\\s*(:)\\s*(\\?)?\\s*([a-zA-Z_\\x{7f}-\\x{7fffffff}][a-zA-Z0-9_\\x{7f}-\\x{7fffffff}]*))?'
+    'end': '(\\))(?:\\s*(:)\\s*(\\?)?\\s*((?:\\\\?[a-zA-Z_\\x{7f}-\\x{7fffffff}][a-zA-Z0-9_\\x{7f}-\\x{7fffffff}]*)+))?'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.parameters.end.bracket.round.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -391,7 +391,7 @@
     'name': 'keyword.control.exception.php'
   }
   {
-    'begin': '(?i)\\b(function)\\s*(?=\\()'
+    'begin': '(?i)\\b(function)\\s*(?=&?\\s*\\()'
     'beginCaptures':
       '1':
         'name': 'storage.type.function.php'
@@ -399,9 +399,11 @@
     'name': 'meta.function.closure.php'
     'patterns': [
       {
-        'begin': '\\('
+        'begin': '(&)?\\s*(\\()'
         'beginCaptures':
-          '0':
+          '1':
+            'name': 'storage.modifier.reference.php'
+          '2':
             'name': 'punctuation.definition.parameters.begin.bracket.round.php'
         'contentName': 'meta.function.parameters.php'
         'end': '\\)'
@@ -448,7 +450,7 @@
       (?i:
         (__(?:call|construct|debugInfo|destruct|get|set|isset|unset|toString|
               clone|set_state|sleep|wakeup|autoload|invoke|callStatic))
-        |([a-zA-Z_\\x{7f}-\\x{7fffffff}][a-zA-Z0-9_\\x{7f}-\\x{7fffffff}]*)
+        |(?:(&)?\\s*([a-zA-Z_\\x{7f}-\\x{7fffffff}][a-zA-Z0-9_\\x{7f}-\\x{7fffffff}]*))
       )
       \\s*(\\()
     '''
@@ -465,8 +467,10 @@
       '3':
         'name': 'support.function.magic.php'
       '4':
-        'name': 'entity.name.function.php'
+        'name': 'storage.modifier.reference.php'
       '5':
+        'name': 'entity.name.function.php'
+      '6':
         'name': 'punctuation.definition.parameters.begin.bracket.round.php'
     'contentName': 'meta.function.parameters.php'
     'end': '(\\))(?:\\s*(:)\\s*(\\?)?\\s*([a-zA-Z_\\x{7f}-\\x{7fffffff}][a-zA-Z0-9_\\x{7f}-\\x{7fffffff}]*))?'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -913,6 +913,15 @@ describe 'PHP grammar', ->
       expect(tokens[6]).toEqual value: '{', scopes: ['source.php', 'punctuation.definition.begin.bracket.curly.php']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.php', 'punctuation.definition.end.bracket.curly.php']
 
+    it 'tokenizes function returning reference', ->
+      {tokens} = grammar.tokenizeLine 'function &test() {}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.php", "storage.type.function.php"]
+      expect(tokens[2]).toEqual value: '&', scopes: ["source.php", "meta.function.php", "storage.modifier.reference.php"]
+      expect(tokens[3]).toEqual value: 'test', scopes: ["source.php", "meta.function.php", "entity.name.function.php"]
+      expect(tokens[4]).toEqual value: '(', scopes: ["source.php", "meta.function.php", "punctuation.definition.parameters.begin.bracket.round.php"]
+      expect(tokens[5]).toEqual value: ')', scopes: ["source.php", "meta.function.php", "punctuation.definition.parameters.end.bracket.round.php"]
+
   describe 'function calls', ->
     it 'tokenizes function calls with no arguments', ->
       {tokens} = grammar.tokenizeLine 'inverse()'
@@ -1061,6 +1070,103 @@ describe 'PHP grammar', ->
       expect(tokens[9]).toEqual value: 'b', scopes: ['source.php', 'meta.method-call.php', 'string.quoted.single.php']
       expect(tokens[10]).toEqual value: "'", scopes: ['source.php', 'meta.method-call.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
       expect(tokens[11]).toEqual value: ')', scopes: ['source.php', 'meta.method-call.php', 'punctuation.definition.arguments.end.bracket.round.php']
+
+  describe 'closures', ->
+    it 'tokenizes parameters', ->
+      {tokens} = grammar.tokenizeLine 'function($a, string $b) {}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
+      expect(tokens[1]).toEqual value: '(', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.begin.bracket.round.php"]
+      expect(tokens[2]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.no-default.php", "variable.other.php", "punctuation.definition.variable.php"]
+      expect(tokens[3]).toEqual value: 'a', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.no-default.php", "variable.other.php"]
+      expect(tokens[4]).toEqual value: ',', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "punctuation.separator.delimiter.php"]
+      expect(tokens[5]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php"]
+      expect(tokens[6]).toEqual value: 'string', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "storage.type.php"]
+      expect(tokens[7]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php"]
+      expect(tokens[8]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "variable.other.php", "punctuation.definition.variable.php"]
+      expect(tokens[9]).toEqual value: 'b', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "variable.other.php"]
+      expect(tokens[10]).toEqual value: ')', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.end.bracket.round.php"]
+
+    it 'tokenizes return values', ->
+      {tokens} = grammar.tokenizeLine 'function() : string {}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
+      expect(tokens[1]).toEqual value: '(', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.begin.bracket.round.php"]
+      expect(tokens[2]).toEqual value: ')', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.end.bracket.round.php"]
+      expect(tokens[3]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php"]
+      expect(tokens[4]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
+      expect(tokens[5]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php"]
+      expect(tokens[6]).toEqual value: 'string', scopes: ["source.php", "meta.function.closure.php", "storage.type.php"]
+      expect(tokens[7]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php"]
+      expect(tokens[8]).toEqual value: '{', scopes: ["source.php", "punctuation.definition.begin.bracket.curly.php"]
+      expect(tokens[9]).toEqual value: '}', scopes: ["source.php", "punctuation.definition.end.bracket.curly.php"]
+
+      {tokens} = grammar.tokenizeLine 'function() : \\Client {}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
+      expect(tokens[4]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
+      expect(tokens[6]).toEqual value: '\\Client', scopes: ["source.php", "meta.function.closure.php", "storage.type.php"]
+
+    it 'tokenizes nullable return values', ->
+      {tokens} = grammar.tokenizeLine 'function() :? Client {}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
+      expect(tokens[4]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
+      expect(tokens[5]).toEqual value: '?', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.nullable-type.php"]
+      expect(tokens[7]).toEqual value: 'Client', scopes: ["source.php", "meta.function.closure.php", "storage.type.php"]
+
+      {tokens} = grammar.tokenizeLine 'function():  ?Client {}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
+      expect(tokens[3]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
+      expect(tokens[5]).toEqual value: '?', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.nullable-type.php"]
+      expect(tokens[6]).toEqual value: 'Client', scopes: ["source.php", "meta.function.closure.php", "storage.type.php"]
+
+    it 'tokenizes closure returning reference', ->
+      {tokens} = grammar.tokenizeLine 'function&() {}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
+      expect(tokens[1]).toEqual value: '&', scopes: ["source.php", "meta.function.closure.php", "storage.modifier.reference.php"]
+      expect(tokens[2]).toEqual value: '(', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.begin.bracket.round.php"]
+      expect(tokens[3]).toEqual value: ')', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.end.bracket.round.php"]
+
+      {tokens} = grammar.tokenizeLine 'function &() {}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
+      expect(tokens[1]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php"]
+      expect(tokens[2]).toEqual value: '&', scopes: ["source.php", "meta.function.closure.php", "storage.modifier.reference.php"]
+      expect(tokens[3]).toEqual value: '(', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.begin.bracket.round.php"]
+      expect(tokens[4]).toEqual value: ')', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.end.bracket.round.php"]
+
+    it 'tokenizes use inheritance', ->
+      {tokens} = grammar.tokenizeLine 'function () use($a) {}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
+      expect(tokens[5]).toEqual value: 'use', scopes: ["source.php", "meta.function.closure.php", "keyword.other.function.use.php"]
+      expect(tokens[6]).toEqual value: '(', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.begin.bracket.round.php"]
+      expect(tokens[7]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php", "punctuation.definition.variable.php"]
+      expect(tokens[8]).toEqual value: 'a', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php"]
+      expect(tokens[9]).toEqual value: ')', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.end.bracket.round.php"]
+
+      {tokens} = grammar.tokenizeLine 'function () use($a  ,$b) {}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
+      expect(tokens[5]).toEqual value: 'use', scopes: ["source.php", "meta.function.closure.php", "keyword.other.function.use.php"]
+      expect(tokens[6]).toEqual value: '(', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.begin.bracket.round.php"]
+      expect(tokens[7]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php", "punctuation.definition.variable.php"]
+      expect(tokens[8]).toEqual value: 'a', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php"]
+      expect(tokens[11]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php", "punctuation.definition.variable.php"]
+      expect(tokens[12]).toEqual value: 'b', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php"]
+      expect(tokens[13]).toEqual value: ')', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.end.bracket.round.php"]
+
+    it 'tokenizes use inheritance by reference', ->
+      {tokens} = grammar.tokenizeLine 'function () use( &$a ) {}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
+      expect(tokens[5]).toEqual value: 'use', scopes: ["source.php", "meta.function.closure.php", "keyword.other.function.use.php"]
+      expect(tokens[8]).toEqual value: '&', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php", "storage.modifier.reference.php"]
+      expect(tokens[9]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php", "punctuation.definition.variable.php"]
+      expect(tokens[10]).toEqual value: 'a', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php"]
 
   describe 'the scope resolution operator', ->
     it 'tokenizes static method calls with no arguments', ->

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1097,7 +1097,7 @@ describe 'PHP grammar', ->
       expect(tokens[4]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
       expect(tokens[5]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php"]
       expect(tokens[6]).toEqual value: 'string', scopes: ["source.php", "meta.function.closure.php", "storage.type.php"]
-      expect(tokens[7]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php"]
+      expect(tokens[7]).toEqual value: ' ', scopes: ["source.php"]
       expect(tokens[8]).toEqual value: '{', scopes: ["source.php", "punctuation.definition.begin.bracket.curly.php"]
       expect(tokens[9]).toEqual value: '}', scopes: ["source.php", "punctuation.definition.end.bracket.curly.php"]
 
@@ -1954,7 +1954,7 @@ describe 'PHP grammar', ->
     expect(tokens[5]).toEqual value: 'function', scopes: ['source.php', 'meta.function.closure.php', 'storage.type.function.php']
     expect(tokens[6]).toEqual value: '(', scopes: ['source.php', 'meta.function.closure.php', 'punctuation.definition.parameters.begin.bracket.round.php']
     expect(tokens[7]).toEqual value: ')', scopes: ['source.php', 'meta.function.closure.php', 'punctuation.definition.parameters.end.bracket.round.php']
-    expect(tokens[8]).toEqual value: ' ', scopes: ['source.php', 'meta.function.closure.php']
+    expect(tokens[8]).toEqual value: ' ', scopes: ['source.php']
     expect(tokens[9]).toEqual value: '{', scopes: ['source.php', 'punctuation.definition.begin.bracket.curly.php']
     expect(tokens[10]).toEqual value: '}', scopes: ['source.php', 'punctuation.definition.end.bracket.curly.php']
     expect(tokens[11]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Functions returning references are now correctly colored #343 
Return types are now correctly identified and colored #367 
Return types now are allowed to include namespaces
Test spec for above
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

Class in return type could be further processed to separate individual parts like namespace, class name. Exactly how function parameters are done, but this is beyond my patience.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Correct colors
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

I hope none
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

fix #343 , fix #367 , fix #320 
<!-- Enter any applicable Issues here -->
