### PR TITLE
Fixes for small issues: ternary, ereg, comments w/ closures

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -399,6 +399,9 @@
     'name': 'meta.function.closure.php'
     'patterns': [
       {
+        'include': '#comments'
+      }
+      {
         'begin': '\\('
         'beginCaptures':
           '0':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2639,7 +2639,7 @@
         'name': 'support.function.enchant.php'
       }
       {
-        'match': '(?i)\\bsplit(i)?|sql_regcase|ereg(i)?(_replace)?\\b'
+        'match': '(?i)\\b(split(i)?|sql_regcase|ereg(i)?(_replace)?)\\b'
         'name': 'support.function.ereg.php'
       }
       {

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -3555,7 +3555,7 @@
     'beginCaptures':
       '0':
         'name': 'keyword.operator.ternary.php'
-    'end': ':'
+    'end': '(?<!:):(?!:)'
     'endCaptures':
       '0':
         'name': 'keyword.operator.ternary.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2650,7 +2650,7 @@
         'name': 'support.function.errorfunc.php'
       }
       {
-        'match': '(?i)\\bshell_exec|system|passthru|proc_(nice|close|terminate|open|get_status)|escapeshell(arg|cmd)|exec\\b'
+        'match': '(?i)\\b(shell_exec|system|passthru|proc_(nice|close|terminate|open|get_status)|escapeshell(arg|cmd)|exec)\\b'
         'name': 'support.function.exec.php'
       }
       {

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -251,10 +251,10 @@ describe 'PHP grammar', ->
         it 'should tokenize ternaries with double colons', ->
           {tokens} = grammar.tokenizeLine 'true ? A::$a : B::$b'
 
-          expect(tokens[2]).toEqual value: '?', scopes: ["source.php","keyword.operator.ternary.php"]
-          expect(tokens[5]).toEqual value: '::', scopes: ["source.php","keyword.operator.class.php"]
-          expect(tokens[9]).toEqual value: ':', scopes: ["source.php","keyword.operator.ternary.php"]
-          expect(tokens[12]).toEqual value: '::', scopes: ["source.php","keyword.operator.class.php"]
+          expect(tokens[2]).toEqual value: '?', scopes: ["source.php", "keyword.operator.ternary.php"]
+          expect(tokens[5]).toEqual value: '::', scopes: ["source.php", "keyword.operator.class.php"]
+          expect(tokens[9]).toEqual value: ':', scopes: ["source.php", "keyword.operator.ternary.php"]
+          expect(tokens[12]).toEqual value: '::', scopes: ["source.php", "keyword.operator.class.php"]
 
   describe 'identifiers', ->
     it 'tokenizes identifiers with only letters', ->
@@ -1864,11 +1864,11 @@ describe 'PHP grammar', ->
   it 'should tokenize comments in closures correctly', ->
     {tokens} = grammar.tokenizeLine '$a = function() /* use($b) */ {};'
 
-    expect(tokens[5]).toEqual value: 'function', scopes: ["source.php","meta.function.closure.php","storage.type.function.php"]
-    expect(tokens[6]).toEqual value: '(', scopes: ["source.php","meta.function.closure.php","punctuation.definition.parameters.begin.bracket.round.php"]
-    expect(tokens[7]).toEqual value: ')', scopes: ["source.php","meta.function.closure.php","punctuation.definition.parameters.end.bracket.round.php"]
-    expect(tokens[9]).toEqual value: '/*', scopes: ["source.php","meta.function.closure.php","comment.block.php","punctuation.definition.comment.php"]
-    expect(tokens[11]).toEqual value: '*/', scopes: ["source.php","meta.function.closure.php","comment.block.php","punctuation.definition.comment.php"]
+    expect(tokens[5]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
+    expect(tokens[6]).toEqual value: '(', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.begin.bracket.round.php"]
+    expect(tokens[7]).toEqual value: ')', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.end.bracket.round.php"]
+    expect(tokens[9]).toEqual value: '/*', scopes: ["source.php", "meta.function.closure.php", "comment.block.php", "punctuation.definition.comment.php"]
+    expect(tokens[11]).toEqual value: '*/', scopes: ["source.php", "meta.function.closure.php", "comment.block.php", "punctuation.definition.comment.php"]
 
   it 'should tokenize non-function-non-control operations correctly', ->
     {tokens} = grammar.tokenizeLine "echo 'test';"

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -248,6 +248,14 @@ describe 'PHP grammar', ->
           expect(lines[1][4]).toEqual value: ':', scopes: ['source.php', 'keyword.operator.ternary.php']
           expect(lines[1][8]).toEqual value: '?:', scopes: ['source.php', 'keyword.operator.ternary.php']
 
+        it 'should tokenize ternaries with double colons', ->
+          {tokens} = grammar.tokenizeLine 'true ? A::$a : B::$b'
+
+          expect(tokens[2]).toEqual value: '?', scopes: ["source.php","keyword.operator.ternary.php"]
+          expect(tokens[5]).toEqual value: '::', scopes: ["source.php","keyword.operator.class.php"]
+          expect(tokens[9]).toEqual value: ':', scopes: ["source.php","keyword.operator.ternary.php"]
+          expect(tokens[12]).toEqual value: '::', scopes: ["source.php","keyword.operator.class.php"]
+
   describe 'identifiers', ->
     it 'tokenizes identifiers with only letters', ->
       {tokens} = grammar.tokenizeLine '$abc'
@@ -1853,6 +1861,15 @@ describe 'PHP grammar', ->
     expect(tokens[10]).toEqual value: '}', scopes: ['source.php', 'punctuation.definition.end.bracket.curly.php']
     expect(tokens[11]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
+  it 'should tokenize comments in closures correctly', ->
+    {tokens} = grammar.tokenizeLine '$a = function() /* use($b) */ {};'
+
+    expect(tokens[5]).toEqual value: 'function', scopes: ["source.php","meta.function.closure.php","storage.type.function.php"]
+    expect(tokens[6]).toEqual value: '(', scopes: ["source.php","meta.function.closure.php","punctuation.definition.parameters.begin.bracket.round.php"]
+    expect(tokens[7]).toEqual value: ')', scopes: ["source.php","meta.function.closure.php","punctuation.definition.parameters.end.bracket.round.php"]
+    expect(tokens[9]).toEqual value: '/*', scopes: ["source.php","meta.function.closure.php","comment.block.php","punctuation.definition.comment.php"]
+    expect(tokens[11]).toEqual value: '*/', scopes: ["source.php","meta.function.closure.php","comment.block.php","punctuation.definition.comment.php"]
+
   it 'should tokenize non-function-non-control operations correctly', ->
     {tokens} = grammar.tokenizeLine "echo 'test';"
 
@@ -1944,7 +1961,7 @@ describe 'PHP grammar', ->
       I am a heredoc
       HEREDOC; // comment
     '''
-    
+
     expect(lines[0][0]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
     expect(lines[0][1]).toEqual value: 'a', scopes: ['source.php', 'variable.other.php']
     expect(lines[0][2]).toEqual value: ' ', scopes: ['source.php']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Fixed ternary operator with double colon #356 (w/ test spec)
Ereg functions won't match part of function name #353
Comments in closures are now properly colored #322 (w/ test spec)
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

None
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Better and happier life
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

None
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

fix #356, fix #353, fix #322
<!-- Enter any applicable Issues here -->
