### PR TITLE
Missing operators: spread, exponentiation, null coalescing

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -584,6 +584,10 @@
     'name': 'keyword.other.clone.php'
   }
   {
+    'match': '\\.\\.\\.'
+    'name': 'keyword.operator.spread.php'
+  }
+  {
     'match': '\\.=?'
     'name': 'keyword.operator.string.php'
   }
@@ -610,7 +614,7 @@
     'name': 'keyword.operator.comparison.php'
   }
   {
-    'match': '=|\\+=|\\-=|\\*=|/=|%=|&=|\\|=|\\^=|<<=|>>='
+    'match': '=|\\+=|\\-=|\\*\\*?=|/=|%=|&=|\\|=|\\^=|<<=|>>=|\\?\\?='
     'name': 'keyword.operator.assignment.php'
   }
   {
@@ -622,7 +626,7 @@
     'name': 'keyword.operator.increment-decrement.php'
   }
   {
-    'match': '\\-|\\+|\\*|/|%'
+    'match': '\\-|\\+|\\*\\*?|/|%'
     'name': 'keyword.operator.arithmetic.php'
   }
   {

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -77,6 +77,16 @@ describe 'PHP grammar', ->
       expect(tokens[4]).toEqual value: '2', scopes: ['source.php', 'constant.numeric.decimal.php']
       expect(tokens[5]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
+    it 'should tokenize ** correctly', ->
+      {tokens} = grammar.tokenizeLine '1 ** 2;'
+
+      expect(tokens[0]).toEqual value: '1', scopes: ['source.php', 'constant.numeric.decimal.php']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['source.php']
+      expect(tokens[2]).toEqual value: '**', scopes: ['source.php', 'keyword.operator.arithmetic.php']
+      expect(tokens[3]).toEqual value: ' ', scopes: ['source.php']
+      expect(tokens[4]).toEqual value: '2', scopes: ['source.php', 'constant.numeric.decimal.php']
+      expect(tokens[5]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+
     describe 'combined operators', ->
       it 'should tokenize === correctly', ->
         {tokens} = grammar.tokenizeLine '$test === 2;'
@@ -210,9 +220,50 @@ describe 'PHP grammar', ->
         expect(tokens[5]).toEqual value: '2', scopes: ['source.php', 'constant.numeric.decimal.php']
         expect(tokens[6]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
+      it 'should tokenize **= correctly', ->
+        {tokens} = grammar.tokenizeLine '$test **= 2;'
+
+        expect(tokens[0]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[1]).toEqual value: 'test', scopes: ['source.php', 'variable.other.php']
+        expect(tokens[2]).toEqual value: ' ', scopes: ['source.php']
+        expect(tokens[3]).toEqual value: '**=', scopes: ['source.php', 'keyword.operator.assignment.php']
+        expect(tokens[4]).toEqual value: ' ', scopes: ['source.php']
+        expect(tokens[5]).toEqual value: '2', scopes: ['source.php', 'constant.numeric.decimal.php']
+        expect(tokens[6]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+
       it 'should tokenize ?? correctly', ->
         {tokens} = grammar.tokenizeLine "$foo = $bar ?? 'bar';"
         expect(tokens[8]).toEqual value: '??', scopes: ['source.php', 'keyword.operator.null-coalescing.php']
+
+      it 'should tokenize ??= correctly', ->
+        {tokens} = grammar.tokenizeLine '$test ??= 2;'
+
+        expect(tokens[0]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[1]).toEqual value: 'test', scopes: ['source.php', 'variable.other.php']
+        expect(tokens[2]).toEqual value: ' ', scopes: ['source.php']
+        expect(tokens[3]).toEqual value: '??=', scopes: ['source.php', 'keyword.operator.assignment.php']
+        expect(tokens[4]).toEqual value: ' ', scopes: ['source.php']
+        expect(tokens[5]).toEqual value: '2', scopes: ['source.php', 'constant.numeric.decimal.php']
+        expect(tokens[6]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+
+      it 'should tokenize ... correctly', ->
+        {tokens} = grammar.tokenizeLine '[0,...$b,2]'
+
+        expect(tokens[0]).toEqual value: '[', scopes: ["source.php", "punctuation.section.array.begin.php"]
+        expect(tokens[3]).toEqual value: '...', scopes: ["source.php", "keyword.operator.spread.php"]
+        expect(tokens[4]).toEqual value: '$', scopes: ["source.php", "variable.other.php", "punctuation.definition.variable.php"]
+        expect(tokens[5]).toEqual value: 'b', scopes: ["source.php", "variable.other.php"]
+        expect(tokens[8]).toEqual value: ']', scopes: ["source.php", "punctuation.section.array.end.php"]
+
+        {tokens} = grammar.tokenizeLine 'test($a, ...$b)'
+
+        expect(tokens[0]).toEqual value: 'test', scopes: ["source.php", "meta.function-call.php", "entity.name.function.php"]
+        expect(tokens[1]).toEqual value: '(', scopes: ["source.php", "meta.function-call.php", "punctuation.definition.arguments.begin.bracket.round.php"]
+        expect(tokens[5]).toEqual value: ' ', scopes: ["source.php", "meta.function-call.php"]
+        expect(tokens[6]).toEqual value: '...', scopes: ["source.php", "meta.function-call.php", "keyword.operator.spread.php"]
+        expect(tokens[7]).toEqual value: '$', scopes: ["source.php", "meta.function-call.php", "variable.other.php", "punctuation.definition.variable.php"]
+        expect(tokens[8]).toEqual value: 'b', scopes: ["source.php", "meta.function-call.php", "variable.other.php"]
+        expect(tokens[9]).toEqual value: ')', scopes: ["source.php", "meta.function-call.php", "punctuation.definition.arguments.end.bracket.round.php"]
 
       describe 'ternaries', ->
         it 'should tokenize ternary expressions', ->


### PR DESCRIPTION
Extracted from #370 

https://wiki.php.net/rfc/spread_operator_for_array
https://wiki.php.net/rfc/null_coalesce_equal_operator
https://wiki.php.net/rfc/pow-operator