### PR TITLE
Support for @filesource and @used-by annotations

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2272,9 +2272,9 @@
         'match': '''(?x)
           @
           (
-            api|abstract|author|category|copyright|example|global|inherit[Dd]oc|internal|
-            license|link|method|property(-(read|write))?|package|param|return|see|since|source|
-            static|subpackage|throws|todo|var|version|uses|deprecated|final|ignore
+            api|abstract|author|category|copyright|example|filesource|global|inherit[Dd]oc|
+            internal|license|link|method|property(-(read|write))?|package|param|return|see|since|
+            source|static|subpackage|throws|todo|var|version|used-by|uses|deprecated|final|ignore
           )\\b
         '''
         'name': 'keyword.other.phpdoc.php'


### PR DESCRIPTION
Hello,
This pull request adds support for PHPDoc's officially supported `@filesource` ([phpDocumentor's reference here](https://docs.phpdoc.org/latest/references/phpdoc/tags/filesource.html)) and `@used-by` ([here](https://docs.phpdoc.org/latest/references/phpdoc/tags/uses.html)) annotations. Note, that these are minimal changes and do not require a proper separate unit test.
Best regards,
Ben.