### PR TITLE
Parse class with capitol letter after instanceof correctly

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -728,11 +728,11 @@
     'name': 'keyword.operator.bitwise.php'
   }
   {
-    'begin': '(?i)\\b(instanceof)\\s+(?=[\\\\$a-zA-Z_])'
+    'begin': '(?i)\\b(instanceof)\\s+(?=[\\\\$a-z_])'
     'beginCaptures':
       '1':
         'name': 'keyword.operator.type.php'
-    'end': '(?=[^\\\\$a-zA-Z0-9_\\x{7f}-\\x{7fffffff}])'
+    'end': '(?i)(?=[^\\\\$a-z0-9_\\x{7f}-\\x{7fffffff}])'
     'patterns': [
       {
         'include': '#class-name'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -728,11 +728,11 @@
     'name': 'keyword.operator.bitwise.php'
   }
   {
-    'begin': '(?i)\\b(instanceof)\\s+(?=[\\\\$a-z_])'
+    'begin': '(?i)\\b(instanceof)\\s+(?=[\\\\$a-zA-Z_])'
     'beginCaptures':
       '1':
         'name': 'keyword.operator.type.php'
-    'end': '(?=[^\\\\$a-z0-9_\\x{7f}-\\x{7fffffff}])'
+    'end': '(?=[^\\\\$a-zA-Z0-9_\\x{7f}-\\x{7fffffff}])'
     'patterns': [
       {
         'include': '#class-name'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -87,6 +87,16 @@ describe 'PHP grammar', ->
       expect(tokens[4]).toEqual value: '2', scopes: ['source.php', 'constant.numeric.decimal.php']
       expect(tokens[5]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
+    it 'should tokenize instanceof correctly', ->
+      {tokens} = grammar.tokenizeLine '$x instanceof Foo'
+
+      expect(tokens[0]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[1]).toEqual value: 'x', scopes: ['source.php', 'variable.other.php']
+      expect(tokens[2]).toEqual value: ' ', scopes: ['source.php']
+      expect(tokens[3]).toEqual value: 'instanceof', scopes: ['source.php', 'keyword.operator.type.php']
+      expect(tokens[4]).toEqual value: ' ', scopes: ['source.php']
+      expect(tokens[5]).toEqual value: 'Foo', scopes: ['source.php', 'support.class.php']
+
     describe 'combined operators', ->
       it 'should tokenize === correctly', ->
         {tokens} = grammar.tokenizeLine '$test === 2;'


### PR DESCRIPTION
### Description of the Change

It looks like the original author of this section did intend to parse the thing after `instanceof` correctly but only included `a-z` not `A-Za-z`. You can see that this does work as expected with class names starting with a lowercase letter.

### Benefits

Show correct coloring for the class name

### Possible Drawbacks

I think this is fairly straightforward

### Applicable Issues

atom/language-php#225
microsoft/vscode#88441
