### PR TITLE
Add scope for PHP primitive types

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -853,7 +853,7 @@
   'primitives':
     'patterns': [
       {
-        'match': '\\b(array|bool|callable|float|int|iterable|object|string)\\b'
+        'match': '^(array|bool|callable|float|int|iterable|object|string)$'
         'name': 'storage.type.primitive.php'
       }
     ]

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1299,7 +1299,7 @@
             'name': 'keyword.operator.nullable-type.php'
           '2':
             'name': 'storage.type.php'
-            patterns: [
+            'patterns': [
               {
                 'include': '#primitives'
               }
@@ -1351,7 +1351,7 @@
             ]
           '3':
             'name': 'storage.type.php'
-            patterns: [
+            'patterns': [
               {
                 'include': '#primitives'
               }

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -658,6 +658,11 @@
         'name': 'punctuation.definition.storage-type.begin.bracket.round.php'
       '2':
         'name': 'storage.type.php'
+        'patterns': [
+          {
+            'include': '#primitives'
+          }
+        ]
       '3':
         'name': 'punctuation.definition.storage-type.end.bracket.round.php'
   }

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -508,6 +508,11 @@
             'name': 'keyword.operator.nullable-type.php'
           '3':
             'name': 'storage.type.php'
+            'patterns': [
+              {
+                'include': '#primitives'
+              }
+            ]
       }
     ]
   }

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1346,6 +1346,11 @@
             ]
           '3':
             'name': 'storage.type.php'
+            patterns: [
+              {
+                'include': '#primitives'
+              }
+            ]
           '4':
             'name': 'variable.other.php'
           '5':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -853,7 +853,7 @@
   'primitives':
     'patterns': [
       {
-        'match': '^(array|bool|callable|float|int|iterable|object|string)$'
+        'match': '^array|bool|callable|float|int|iterable|object|string$'
         'name': 'storage.type.primitive.php'
       }
     ]

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -556,6 +556,11 @@
         'name': 'keyword.operator.nullable-type.php'
       '4':
         'name': 'storage.type.php'
+        'patterns': [
+          {
+            'include': '#primitives'
+          }
+        ]
     'name': 'meta.function.php'
     'patterns': [
       {

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -462,6 +462,11 @@
             'name': 'keyword.operator.nullable-type.php'
           '3':
             'name': 'storage.type.php'
+            'patterns': [
+              {
+                'include': '#primitives'
+              }
+            ]
       }
     ]
   }

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -585,6 +585,11 @@
         ]
       '4':
         'name': 'storage.type.php'
+        'patterns': [
+          {
+            'include': '#primitives'
+          }
+        ]
       '5':
         'name': 'variable.other.php'
       '6':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -853,7 +853,7 @@
   'primitives':
     'patterns': [
       {
-        'match': 'array|bool|callable|float|int|iterable|object|string'
+        'match': '\\b(array|bool|callable|float|int|iterable|object|string)\\b'
         'name': 'storage.type.primitive.php'
       }
     ]

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -825,6 +825,13 @@
   }
 ]
 'repository':
+  'primitives':
+    'patterns': [
+      {
+        'match': 'array|bool|callable|float|int|iterable|object|string'
+        'name': 'storage.primitive.php'
+      }
+    ]
   'class-builtin':
     'patterns': [
       {

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -854,7 +854,7 @@
     'patterns': [
       {
         'match': 'array|bool|callable|float|int|iterable|object|string'
-        'name': 'storage.primitive.php'
+        'name': 'storage.type.primitive.php'
       }
     ]
   'class-builtin':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -853,7 +853,7 @@
   'primitives':
     'patterns': [
       {
-        'match': '^array|bool|callable|float|int|iterable|object|string$'
+        'match': '\\b(array|bool|callable|float|int|iterable|object|string)\\b'
         'name': 'storage.type.primitive.php'
       }
     ]

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1299,6 +1299,11 @@
             'name': 'keyword.operator.nullable-type.php'
           '2':
             'name': 'storage.type.php'
+            patterns: [
+              {
+                'include': '#primitives'
+              }
+            ]
           '3':
             'name': 'variable.other.php'
           '4':

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -648,7 +648,7 @@ describe 'PHP grammar', ->
         '''
 
         expect(lines[1][1]).toEqual value: 'public', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
-        expect(lines[1][3]).toEqual value: 'int', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.primitive.php']
+        expect(lines[1][3]).toEqual value: 'int', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.type.primitive.php']
         expect(lines[1][5]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
         expect(lines[1][6]).toEqual value: 'a', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php"]
 
@@ -661,7 +661,7 @@ describe 'PHP grammar', ->
 
         expect(lines[1][1]).toEqual value: 'static', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
         expect(lines[1][3]).toEqual value: '?', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "keyword.operator.nullable-type.php"]
-        expect(lines[1][4]).toEqual value: 'string', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.primitive.php']
+        expect(lines[1][4]).toEqual value: 'string', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.type.primitive.php']
         expect(lines[1][6]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
         expect(lines[1][7]).toEqual value: 'b', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php"]
 
@@ -673,7 +673,7 @@ describe 'PHP grammar', ->
 
         expect(lines[1][1]).toEqual value: 'static', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
         expect(lines[1][2]).toEqual value: '?', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "keyword.operator.nullable-type.php"]
-        expect(lines[1][4]).toEqual value: 'string', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.primitive.php']
+        expect(lines[1][4]).toEqual value: 'string', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.type.primitive.php']
 
       it 'tokenizes namespaces', ->
         lines = grammar.tokenizeLines '''
@@ -701,7 +701,7 @@ describe 'PHP grammar', ->
         '''
 
         expect(lines[1][1]).toEqual value: 'static', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
-        expect(lines[1][3]).toEqual value: 'int', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.primitive.php']
+        expect(lines[1][3]).toEqual value: 'int', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.type.primitive.php']
         expect(lines[1][5]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
         expect(lines[1][6]).toEqual value: 'a', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php"]
 
@@ -716,7 +716,7 @@ describe 'PHP grammar', ->
         expect(lines[3][1]).toEqual value: 'private', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
         expect(lines[3][3]).toEqual value: 'static', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
         expect(lines[3][5]).toEqual value: '?', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "keyword.operator.nullable-type.php"]
-        expect(lines[3][7]).toEqual value: 'array', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.primitive.php']
+        expect(lines[3][7]).toEqual value: 'array', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.type.primitive.php']
         expect(lines[3][9]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
         expect(lines[3][10]).toEqual value: 'c1', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php"]
         expect(lines[3][13]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
@@ -984,7 +984,7 @@ describe 'PHP grammar', ->
       expect(tokens[1]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php']
       expect(tokens[2]).toEqual value: 'array_test', scopes: ['source.php', 'meta.function.php', 'entity.name.function.php']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
-      expect(tokens[4]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[4]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'storage.type.php', 'storage.type.primitive.php']
       expect(tokens[5]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php']
       expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'variable.other.php', 'punctuation.definition.variable.php']
       expect(tokens[7]).toEqual value: 'value', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'variable.other.php']
@@ -1034,31 +1034,31 @@ describe 'PHP grammar', ->
 
     it 'tokenizes primitive types in function parameter typehints', ->
       {tokens} = grammar.tokenizeLine "function type_test(array $value) {}"
-      expect(tokens[4]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[4]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'storage.type.php', 'storage.type.primitive.php']
 
       {tokens} = grammar.tokenizeLine "function type_test(bool $value) {}"
-      expect(tokens[4]).toEqual value: 'bool', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[4]).toEqual value: 'bool', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.type.primitive.php']
 
       {tokens} = grammar.tokenizeLine "function type_test(bool $value = false) {}"
-      expect(tokens[4]).toEqual value: 'bool', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[4]).toEqual value: 'bool', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.type.primitive.php']
 
       {tokens} = grammar.tokenizeLine "function type_test(int $value = 1) {}"
-      expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.type.primitive.php']
 
       {tokens} = grammar.tokenizeLine "function type_test(?bool $value = null) {}"
-      expect(tokens[5]).toEqual value: 'bool', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[5]).toEqual value: 'bool', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.type.primitive.php']
 
       {tokens} = grammar.tokenizeLine "function type_test(callable $value) {}"
-      expect(tokens[4]).toEqual value: 'callable', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[4]).toEqual value: 'callable', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'storage.type.php', 'storage.type.primitive.php']
 
       {tokens} = grammar.tokenizeLine "function type_test(iterable $value) {}"
-      expect(tokens[4]).toEqual value: 'iterable', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[4]).toEqual value: 'iterable', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.type.primitive.php']
 
       {tokens} = grammar.tokenizeLine "function type_test(?object $value) {}"
-      expect(tokens[5]).toEqual value: 'object', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[5]).toEqual value: 'object', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.type.primitive.php']
 
       {tokens} = grammar.tokenizeLine "function type_test(string $value = 'default') {}"
-      expect(tokens[4]).toEqual value: 'string', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[4]).toEqual value: 'string', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.type.primitive.php']
 
     it 'tokenizes multiple typehinted arguments with default values', ->
       {tokens} = grammar.tokenizeLine "function test(string $subject = 'no subject', string $body = null) {}"
@@ -1067,7 +1067,7 @@ describe 'PHP grammar', ->
       expect(tokens[1]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php']
       expect(tokens[2]).toEqual value: 'test', scopes: ['source.php', 'meta.function.php', 'entity.name.function.php']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
-      expect(tokens[4]).toEqual value: 'string', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[4]).toEqual value: 'string', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.type.primitive.php']
       expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
       expect(tokens[7]).toEqual value: 'subject', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
       expect(tokens[8]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
@@ -1078,7 +1078,7 @@ describe 'PHP grammar', ->
       expect(tokens[13]).toEqual value: "'", scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
       expect(tokens[14]).toEqual value: ',', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'punctuation.separator.delimiter.php']
       expect(tokens[15]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php']
-      expect(tokens[16]).toEqual value: 'string', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[16]).toEqual value: 'string', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.type.primitive.php']
       expect(tokens[18]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
       expect(tokens[19]).toEqual value: 'body', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
       expect(tokens[21]).toEqual value: '=', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'keyword.operator.assignment.php']
@@ -1118,16 +1118,16 @@ describe 'PHP grammar', ->
 
     it 'tokenizes primitive return types', ->
       {tokens} = grammar.tokenizeLine 'function test() : string {}'
-      expect(tokens[8]).toEqual value: 'string', scopes: ['source.php', 'meta.function.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[8]).toEqual value: 'string', scopes: ['source.php', 'meta.function.php', 'storage.type.php', 'storage.type.primitive.php']
 
       {tokens} = grammar.tokenizeLine 'function test() : bool {}'
-      expect(tokens[8]).toEqual value: 'bool', scopes: ['source.php', 'meta.function.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[8]).toEqual value: 'bool', scopes: ['source.php', 'meta.function.php', 'storage.type.php', 'storage.type.primitive.php']
 
       {tokens} = grammar.tokenizeLine 'function test() : ?int {}'
-      expect(tokens[9]).toEqual value: 'int', scopes: ['source.php', 'meta.function.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[9]).toEqual value: 'int', scopes: ['source.php', 'meta.function.php', 'storage.type.php', 'storage.type.primitive.php']
 
       {tokens} = grammar.tokenizeLine 'function test() : ?array {}'
-      expect(tokens[9]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'storage.type.php', 'storage.primitive.php']
+      expect(tokens[9]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'storage.type.php', 'storage.type.primitive.php']
 
     it 'tokenizes function names with characters other than letters or numbers', ->
       # Char 160 is hex 0xA0, which is between 0x7F and 0xFF, making it a valid PHP identifier
@@ -1311,7 +1311,7 @@ describe 'PHP grammar', ->
       expect(tokens[3]).toEqual value: 'a', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.no-default.php", "variable.other.php"]
       expect(tokens[4]).toEqual value: ',', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "punctuation.separator.delimiter.php"]
       expect(tokens[5]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php"]
-      expect(tokens[6]).toEqual value: 'string', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "storage.type.php", 'storage.primitive.php']
+      expect(tokens[6]).toEqual value: 'string', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "storage.type.php", 'storage.type.primitive.php']
       expect(tokens[7]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php"]
       expect(tokens[8]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "variable.other.php", "punctuation.definition.variable.php"]
       expect(tokens[9]).toEqual value: 'b', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "variable.other.php"]
@@ -1326,7 +1326,7 @@ describe 'PHP grammar', ->
       expect(tokens[3]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php"]
       expect(tokens[4]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
       expect(tokens[5]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php"]
-      expect(tokens[6]).toEqual value: 'string', scopes: ["source.php", "meta.function.closure.php", "storage.type.php", 'storage.primitive.php']
+      expect(tokens[6]).toEqual value: 'string', scopes: ["source.php", "meta.function.closure.php", "storage.type.php", 'storage.type.primitive.php']
       expect(tokens[7]).toEqual value: ' ', scopes: ["source.php"]
       expect(tokens[8]).toEqual value: '{', scopes: ["source.php", "punctuation.definition.begin.bracket.curly.php"]
       expect(tokens[9]).toEqual value: '}', scopes: ["source.php", "punctuation.definition.end.bracket.curly.php"]
@@ -1357,7 +1357,7 @@ describe 'PHP grammar', ->
       expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
       expect(tokens[3]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
       expect(tokens[5]).toEqual value: '?', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.nullable-type.php"]
-      expect(tokens[6]).toEqual value: 'bool', scopes: ["source.php", "meta.function.closure.php", "storage.type.php", 'storage.primitive.php']
+      expect(tokens[6]).toEqual value: 'bool', scopes: ["source.php", "meta.function.closure.php", "storage.type.php", 'storage.type.primitive.php']
 
     it 'tokenizes closure returning reference', ->
       {tokens} = grammar.tokenizeLine 'function&() {}'
@@ -1425,7 +1425,7 @@ describe 'PHP grammar', ->
       {tokens} = grammar.tokenizeLine '$pow = fn(int $x=0) => $x * 2;'
 
       expect(tokens[5]).toEqual value: 'fn', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
-      expect(tokens[7]).toEqual value: 'int', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "storage.type.php", 'storage.primitive.php']
+      expect(tokens[7]).toEqual value: 'int', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "storage.type.php", 'storage.type.primitive.php']
       expect(tokens[9]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "variable.other.php", "punctuation.definition.variable.php"]
       expect(tokens[10]).toEqual value: 'x', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "variable.other.php"]
       expect(tokens[11]).toEqual value: '=', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "keyword.operator.assignment.php"]
@@ -1438,7 +1438,7 @@ describe 'PHP grammar', ->
       expect(tokens[5]).toEqual value: 'fn', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
       expect(tokens[11]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
       expect(tokens[12]).toEqual value: '?', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.nullable-type.php"]
-      expect(tokens[14]).toEqual value: 'int', scopes: ["source.php", "meta.function.closure.php", "storage.type.php", 'storage.primitive.php']
+      expect(tokens[14]).toEqual value: 'int', scopes: ["source.php", "meta.function.closure.php", "storage.type.php", 'storage.type.primitive.php']
 
   describe 'the scope resolution operator', ->
     it 'tokenizes static method calls with no arguments', ->
@@ -1802,14 +1802,14 @@ describe 'PHP grammar', ->
     {tokens} = grammar.tokenizeLine '(int)'
 
     expect(tokens[0]).toEqual value: '(', scopes: ['source.php', 'punctuation.definition.storage-type.begin.bracket.round.php']
-    expect(tokens[1]).toEqual value: 'int', scopes: ['source.php', 'storage.type.php', 'storage.primitive.php']
+    expect(tokens[1]).toEqual value: 'int', scopes: ['source.php', 'storage.type.php', 'storage.type.primitive.php']
     expect(tokens[2]).toEqual value: ')', scopes: ['source.php', 'punctuation.definition.storage-type.end.bracket.round.php']
 
     {tokens} = grammar.tokenizeLine '( int )'
 
     expect(tokens[0]).toEqual value: '(', scopes: ['source.php', 'punctuation.definition.storage-type.begin.bracket.round.php']
     expect(tokens[1]).toEqual value: ' ', scopes: ['source.php']
-    expect(tokens[2]).toEqual value: 'int', scopes: ['source.php', 'storage.type.php', 'storage.primitive.php']
+    expect(tokens[2]).toEqual value: 'int', scopes: ['source.php', 'storage.type.php', 'storage.type.primitive.php']
     expect(tokens[3]).toEqual value: ' ', scopes: ['source.php']
     expect(tokens[4]).toEqual value: ')', scopes: ['source.php', 'punctuation.definition.storage-type.end.bracket.round.php']
 

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1774,14 +1774,14 @@ describe 'PHP grammar', ->
     {tokens} = grammar.tokenizeLine '(int)'
 
     expect(tokens[0]).toEqual value: '(', scopes: ['source.php', 'punctuation.definition.storage-type.begin.bracket.round.php']
-    expect(tokens[1]).toEqual value: 'int', scopes: ['source.php', 'storage.type.php']
+    expect(tokens[1]).toEqual value: 'int', scopes: ['source.php', 'storage.type.php', 'storage.primitive.php']
     expect(tokens[2]).toEqual value: ')', scopes: ['source.php', 'punctuation.definition.storage-type.end.bracket.round.php']
 
     {tokens} = grammar.tokenizeLine '( int )'
 
     expect(tokens[0]).toEqual value: '(', scopes: ['source.php', 'punctuation.definition.storage-type.begin.bracket.round.php']
     expect(tokens[1]).toEqual value: ' ', scopes: ['source.php']
-    expect(tokens[2]).toEqual value: 'int', scopes: ['source.php', 'storage.type.php']
+    expect(tokens[2]).toEqual value: 'int', scopes: ['source.php', 'storage.type.php', 'storage.primitive.php']
     expect(tokens[3]).toEqual value: ' ', scopes: ['source.php']
     expect(tokens[4]).toEqual value: ')', scopes: ['source.php', 'punctuation.definition.storage-type.end.bracket.round.php']
 

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -648,7 +648,7 @@ describe 'PHP grammar', ->
         '''
 
         expect(lines[1][1]).toEqual value: 'public', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
-        expect(lines[1][3]).toEqual value: 'int', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php"]
+        expect(lines[1][3]).toEqual value: 'int', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.primitive.php']
         expect(lines[1][5]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
         expect(lines[1][6]).toEqual value: 'a', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php"]
 
@@ -661,7 +661,7 @@ describe 'PHP grammar', ->
 
         expect(lines[1][1]).toEqual value: 'static', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
         expect(lines[1][3]).toEqual value: '?', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "keyword.operator.nullable-type.php"]
-        expect(lines[1][4]).toEqual value: 'string', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php"]
+        expect(lines[1][4]).toEqual value: 'string', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.primitive.php']
         expect(lines[1][6]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
         expect(lines[1][7]).toEqual value: 'b', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php"]
 
@@ -673,7 +673,7 @@ describe 'PHP grammar', ->
 
         expect(lines[1][1]).toEqual value: 'static', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
         expect(lines[1][2]).toEqual value: '?', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "keyword.operator.nullable-type.php"]
-        expect(lines[1][4]).toEqual value: 'string', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php"]
+        expect(lines[1][4]).toEqual value: 'string', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.primitive.php']
 
       it 'tokenizes namespaces', ->
         lines = grammar.tokenizeLines '''
@@ -701,7 +701,7 @@ describe 'PHP grammar', ->
         '''
 
         expect(lines[1][1]).toEqual value: 'static', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
-        expect(lines[1][3]).toEqual value: 'int', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php"]
+        expect(lines[1][3]).toEqual value: 'int', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.primitive.php']
         expect(lines[1][5]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
         expect(lines[1][6]).toEqual value: 'a', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php"]
 
@@ -716,7 +716,7 @@ describe 'PHP grammar', ->
         expect(lines[3][1]).toEqual value: 'private', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
         expect(lines[3][3]).toEqual value: 'static', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
         expect(lines[3][5]).toEqual value: '?', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "keyword.operator.nullable-type.php"]
-        expect(lines[3][7]).toEqual value: 'array', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php"]
+        expect(lines[3][7]).toEqual value: 'array', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.primitive.php']
         expect(lines[3][9]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
         expect(lines[3][10]).toEqual value: 'c1', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php"]
         expect(lines[3][13]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1305,7 +1305,7 @@ describe 'PHP grammar', ->
       expect(tokens[3]).toEqual value: 'a', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.no-default.php", "variable.other.php"]
       expect(tokens[4]).toEqual value: ',', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "punctuation.separator.delimiter.php"]
       expect(tokens[5]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php"]
-      expect(tokens[6]).toEqual value: 'string', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "storage.type.php"]
+      expect(tokens[6]).toEqual value: 'string', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "storage.type.php", 'storage.primitive.php']
       expect(tokens[7]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php"]
       expect(tokens[8]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "variable.other.php", "punctuation.definition.variable.php"]
       expect(tokens[9]).toEqual value: 'b', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "variable.other.php"]
@@ -1419,7 +1419,7 @@ describe 'PHP grammar', ->
       {tokens} = grammar.tokenizeLine '$pow = fn(int $x=0) => $x * 2;'
 
       expect(tokens[5]).toEqual value: 'fn', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
-      expect(tokens[7]).toEqual value: 'int', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "storage.type.php"]
+      expect(tokens[7]).toEqual value: 'int', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "storage.type.php", 'storage.primitive.php']
       expect(tokens[9]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "variable.other.php", "punctuation.definition.variable.php"]
       expect(tokens[10]).toEqual value: 'x', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "variable.other.php"]
       expect(tokens[11]).toEqual value: '=', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "keyword.operator.assignment.php"]

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1032,6 +1032,28 @@ describe 'PHP grammar', ->
       expect(tokens[15]).toEqual value: '{', scopes: ['source.php', 'punctuation.definition.begin.bracket.curly.php']
       expect(tokens[16]).toEqual value: '}', scopes: ['source.php', 'punctuation.definition.end.bracket.curly.php']
 
+    it 'tokenizes primitive types in function parameter typehints', ->
+      {tokens} = grammar.tokenizeLine "function type_test(bool $value) {}"
+      expect(tokens[4]).toEqual value: 'bool', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+
+      {tokens} = grammar.tokenizeLine "function type_test(bool $value = false) {}"
+      expect(tokens[4]).toEqual value: 'bool', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+
+      {tokens} = grammar.tokenizeLine "function type_test(int $value = 1) {}"
+      expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+
+      {tokens} = grammar.tokenizeLine "function type_test(?bool $value = null) {}"
+      expect(tokens[5]).toEqual value: 'bool', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+
+      {tokens} = grammar.tokenizeLine "function type_test(iterable $value) {}"
+      expect(tokens[4]).toEqual value: 'iterable', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+
+      {tokens} = grammar.tokenizeLine "function type_test(?object $value) {}"
+      expect(tokens[5]).toEqual value: 'object', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+
+      {tokens} = grammar.tokenizeLine "function type_test(string $value = 'default') {}"
+      expect(tokens[4]).toEqual value: 'string', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+
     it 'tokenizes multiple typehinted arguments with default values', ->
       {tokens} = grammar.tokenizeLine "function test(string $subject = 'no subject', string $body = null) {}"
 
@@ -1039,7 +1061,7 @@ describe 'PHP grammar', ->
       expect(tokens[1]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php']
       expect(tokens[2]).toEqual value: 'test', scopes: ['source.php', 'meta.function.php', 'entity.name.function.php']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
-      expect(tokens[4]).toEqual value: 'string', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+      expect(tokens[4]).toEqual value: 'string', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
       expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
       expect(tokens[7]).toEqual value: 'subject', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
       expect(tokens[8]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
@@ -1050,7 +1072,7 @@ describe 'PHP grammar', ->
       expect(tokens[13]).toEqual value: "'", scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
       expect(tokens[14]).toEqual value: ',', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'punctuation.separator.delimiter.php']
       expect(tokens[15]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php']
-      expect(tokens[16]).toEqual value: 'string', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+      expect(tokens[16]).toEqual value: 'string', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
       expect(tokens[18]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
       expect(tokens[19]).toEqual value: 'body', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
       expect(tokens[21]).toEqual value: '=', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'keyword.operator.assignment.php']

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1285,7 +1285,7 @@ describe 'PHP grammar', ->
       expect(tokens[3]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php"]
       expect(tokens[4]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
       expect(tokens[5]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php"]
-      expect(tokens[6]).toEqual value: 'string', scopes: ["source.php", "meta.function.closure.php", "storage.type.php"]
+      expect(tokens[6]).toEqual value: 'string', scopes: ["source.php", "meta.function.closure.php", "storage.type.php", 'storage.primitive.php']
       expect(tokens[7]).toEqual value: ' ', scopes: ["source.php"]
       expect(tokens[8]).toEqual value: '{', scopes: ["source.php", "punctuation.definition.begin.bracket.curly.php"]
       expect(tokens[9]).toEqual value: '}', scopes: ["source.php", "punctuation.definition.end.bracket.curly.php"]
@@ -1310,6 +1310,13 @@ describe 'PHP grammar', ->
       expect(tokens[3]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
       expect(tokens[5]).toEqual value: '?', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.nullable-type.php"]
       expect(tokens[6]).toEqual value: 'Client', scopes: ["source.php", "meta.function.closure.php", "storage.type.php"]
+
+      {tokens} = grammar.tokenizeLine 'function(): ?bool {}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
+      expect(tokens[3]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
+      expect(tokens[5]).toEqual value: '?', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.nullable-type.php"]
+      expect(tokens[6]).toEqual value: 'bool', scopes: ["source.php", "meta.function.closure.php", "storage.type.php", 'storage.primitive.php']
 
     it 'tokenizes closure returning reference', ->
       {tokens} = grammar.tokenizeLine 'function&() {}'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -648,7 +648,7 @@ describe 'PHP grammar', ->
         '''
 
         expect(lines[1][1]).toEqual value: 'public', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
-        expect(lines[1][3]).toEqual value: 'int', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.type.primitive.php']
+        expect(lines[1][3]).toEqual value: 'int', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", "storage.type.primitive.php"]
         expect(lines[1][5]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
         expect(lines[1][6]).toEqual value: 'a', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php"]
 
@@ -661,7 +661,7 @@ describe 'PHP grammar', ->
 
         expect(lines[1][1]).toEqual value: 'static', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
         expect(lines[1][3]).toEqual value: '?', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "keyword.operator.nullable-type.php"]
-        expect(lines[1][4]).toEqual value: 'string', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.type.primitive.php']
+        expect(lines[1][4]).toEqual value: 'string', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", "storage.type.primitive.php"]
         expect(lines[1][6]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
         expect(lines[1][7]).toEqual value: 'b', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php"]
 
@@ -673,7 +673,7 @@ describe 'PHP grammar', ->
 
         expect(lines[1][1]).toEqual value: 'static', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
         expect(lines[1][2]).toEqual value: '?', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "keyword.operator.nullable-type.php"]
-        expect(lines[1][4]).toEqual value: 'string', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.type.primitive.php']
+        expect(lines[1][4]).toEqual value: 'string', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", "storage.type.primitive.php"]
 
       it 'tokenizes namespaces', ->
         lines = grammar.tokenizeLines '''
@@ -701,7 +701,7 @@ describe 'PHP grammar', ->
         '''
 
         expect(lines[1][1]).toEqual value: 'static', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
-        expect(lines[1][3]).toEqual value: 'int', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.type.primitive.php']
+        expect(lines[1][3]).toEqual value: 'int', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", "storage.type.primitive.php"]
         expect(lines[1][5]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
         expect(lines[1][6]).toEqual value: 'a', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php"]
 
@@ -716,7 +716,7 @@ describe 'PHP grammar', ->
         expect(lines[3][1]).toEqual value: 'private', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
         expect(lines[3][3]).toEqual value: 'static', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
         expect(lines[3][5]).toEqual value: '?', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "keyword.operator.nullable-type.php"]
-        expect(lines[3][7]).toEqual value: 'array', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", 'storage.type.primitive.php']
+        expect(lines[3][7]).toEqual value: 'array', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php", "storage.type.primitive.php"]
         expect(lines[3][9]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
         expect(lines[3][10]).toEqual value: 'c1', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php"]
         expect(lines[3][13]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
@@ -1311,7 +1311,7 @@ describe 'PHP grammar', ->
       expect(tokens[3]).toEqual value: 'a', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.no-default.php", "variable.other.php"]
       expect(tokens[4]).toEqual value: ',', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "punctuation.separator.delimiter.php"]
       expect(tokens[5]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php"]
-      expect(tokens[6]).toEqual value: 'string', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "storage.type.php", 'storage.type.primitive.php']
+      expect(tokens[6]).toEqual value: 'string', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "storage.type.php", "storage.type.primitive.php"]
       expect(tokens[7]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php"]
       expect(tokens[8]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "variable.other.php", "punctuation.definition.variable.php"]
       expect(tokens[9]).toEqual value: 'b', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "variable.other.php"]
@@ -1326,7 +1326,7 @@ describe 'PHP grammar', ->
       expect(tokens[3]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php"]
       expect(tokens[4]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
       expect(tokens[5]).toEqual value: ' ', scopes: ["source.php", "meta.function.closure.php"]
-      expect(tokens[6]).toEqual value: 'string', scopes: ["source.php", "meta.function.closure.php", "storage.type.php", 'storage.type.primitive.php']
+      expect(tokens[6]).toEqual value: 'string', scopes: ["source.php", "meta.function.closure.php", "storage.type.php", "storage.type.primitive.php"]
       expect(tokens[7]).toEqual value: ' ', scopes: ["source.php"]
       expect(tokens[8]).toEqual value: '{', scopes: ["source.php", "punctuation.definition.begin.bracket.curly.php"]
       expect(tokens[9]).toEqual value: '}', scopes: ["source.php", "punctuation.definition.end.bracket.curly.php"]
@@ -1357,7 +1357,7 @@ describe 'PHP grammar', ->
       expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
       expect(tokens[3]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
       expect(tokens[5]).toEqual value: '?', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.nullable-type.php"]
-      expect(tokens[6]).toEqual value: 'bool', scopes: ["source.php", "meta.function.closure.php", "storage.type.php", 'storage.type.primitive.php']
+      expect(tokens[6]).toEqual value: 'bool', scopes: ["source.php", "meta.function.closure.php", "storage.type.php", "storage.type.primitive.php"]
 
     it 'tokenizes closure returning reference', ->
       {tokens} = grammar.tokenizeLine 'function&() {}'
@@ -1425,7 +1425,7 @@ describe 'PHP grammar', ->
       {tokens} = grammar.tokenizeLine '$pow = fn(int $x=0) => $x * 2;'
 
       expect(tokens[5]).toEqual value: 'fn', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
-      expect(tokens[7]).toEqual value: 'int', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "storage.type.php", 'storage.type.primitive.php']
+      expect(tokens[7]).toEqual value: 'int', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "storage.type.php", "storage.type.primitive.php"]
       expect(tokens[9]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "variable.other.php", "punctuation.definition.variable.php"]
       expect(tokens[10]).toEqual value: 'x', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "variable.other.php"]
       expect(tokens[11]).toEqual value: '=', scopes: ["source.php", "meta.function.closure.php", "meta.function.parameters.php", "meta.function.parameter.typehinted.php", "keyword.operator.assignment.php"]
@@ -1438,7 +1438,7 @@ describe 'PHP grammar', ->
       expect(tokens[5]).toEqual value: 'fn', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
       expect(tokens[11]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
       expect(tokens[12]).toEqual value: '?', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.nullable-type.php"]
-      expect(tokens[14]).toEqual value: 'int', scopes: ["source.php", "meta.function.closure.php", "storage.type.php", 'storage.type.primitive.php']
+      expect(tokens[14]).toEqual value: 'int', scopes: ["source.php", "meta.function.closure.php", "storage.type.php", "storage.type.primitive.php"]
 
   describe 'the scope resolution operator', ->
     it 'tokenizes static method calls with no arguments', ->

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1088,6 +1088,19 @@ describe 'PHP grammar', ->
       expect(tokens[9]).toEqual value: '   ', scopes: ['source.php', 'meta.function.php']
       expect(tokens[10]).toEqual value: 'Client', scopes: ['source.php', 'meta.function.php', 'storage.type.php']
 
+    it 'tokenizes primitive return types', ->
+      {tokens} = grammar.tokenizeLine 'function test() : string {}'
+      expect(tokens[8]).toEqual value: 'string', scopes: ['source.php', 'meta.function.php', 'storage.type.php', 'storage.primitive.php']
+
+      {tokens} = grammar.tokenizeLine 'function test() : bool {}'
+      expect(tokens[8]).toEqual value: 'bool', scopes: ['source.php', 'meta.function.php', 'storage.type.php', 'storage.primitive.php']
+
+      {tokens} = grammar.tokenizeLine 'function test() : ?int {}'
+      expect(tokens[9]).toEqual value: 'int', scopes: ['source.php', 'meta.function.php', 'storage.type.php', 'storage.primitive.php']
+
+      {tokens} = grammar.tokenizeLine 'function test() : ?array {}'
+      expect(tokens[9]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'storage.type.php', 'storage.primitive.php']
+
     it 'tokenizes function names with characters other than letters or numbers', ->
       # Char 160 is hex 0xA0, which is between 0x7F and 0xFF, making it a valid PHP identifier
       functionName = "foo#{String.fromCharCode(160)}bar"

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1397,7 +1397,7 @@ describe 'PHP grammar', ->
       expect(tokens[5]).toEqual value: 'fn', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
       expect(tokens[11]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
       expect(tokens[12]).toEqual value: '?', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.nullable-type.php"]
-      expect(tokens[14]).toEqual value: 'int', scopes: ["source.php", "meta.function.closure.php", "storage.type.php"]
+      expect(tokens[14]).toEqual value: 'int', scopes: ["source.php", "meta.function.closure.php", "storage.type.php", 'storage.primitive.php']
 
   describe 'the scope resolution operator', ->
     it 'tokenizes static method calls with no arguments', ->

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -984,7 +984,7 @@ describe 'PHP grammar', ->
       expect(tokens[1]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php']
       expect(tokens[2]).toEqual value: 'array_test', scopes: ['source.php', 'meta.function.php', 'entity.name.function.php']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
-      expect(tokens[4]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'storage.type.php']
+      expect(tokens[4]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'storage.type.php', 'storage.primitive.php']
       expect(tokens[5]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php']
       expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'variable.other.php', 'punctuation.definition.variable.php']
       expect(tokens[7]).toEqual value: 'value', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'variable.other.php']
@@ -1033,6 +1033,9 @@ describe 'PHP grammar', ->
       expect(tokens[16]).toEqual value: '}', scopes: ['source.php', 'punctuation.definition.end.bracket.curly.php']
 
     it 'tokenizes primitive types in function parameter typehints', ->
+      {tokens} = grammar.tokenizeLine "function type_test(array $value) {}"
+      expect(tokens[4]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'storage.type.php', 'storage.primitive.php']
+
       {tokens} = grammar.tokenizeLine "function type_test(bool $value) {}"
       expect(tokens[4]).toEqual value: 'bool', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
 
@@ -1044,6 +1047,9 @@ describe 'PHP grammar', ->
 
       {tokens} = grammar.tokenizeLine "function type_test(?bool $value = null) {}"
       expect(tokens[5]).toEqual value: 'bool', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']
+
+      {tokens} = grammar.tokenizeLine "function type_test(callable $value) {}"
+      expect(tokens[4]).toEqual value: 'callable', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'storage.type.php', 'storage.primitive.php']
 
       {tokens} = grammar.tokenizeLine "function type_test(iterable $value) {}"
       expect(tokens[4]).toEqual value: 'iterable', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php', 'storage.primitive.php']


### PR DESCRIPTION
PHP has 10 ["primitive" types](https://www.php.net/manual/en/language.types.intro.php), 8 of which are relevant to this PR because they can be used as [argument typehints](https://www.php.net/manual/en/functions.arguments.php): `bool`, `int`, `float`, `string`, `array`, `object`, `iterable`, and `callable`.

These primitive types are not classes, but they can be used in some of the same ways as class names, notably for typed properties, parameter types, and return types:

```php
class Car
{
    public int $wheels = 4;

    public function addWheels(int $wheels): int
    {
        $this->wheels = $this->wheels + $wheels;

        return $this->wheels;
    }
}
```

### Description of the Change

This PR adds the `storage.primitive.php` scope for the 8 primitive types listed above. This scope has been added everywhere these types might appear, including in function parameter typehints, object method parameter typehints, return types, typed properties, and typecasts.

I chose `storage.primitive.php` as the scope name because it's short, descriptive, and very similar to the existing `storage.type.php`, but I welcome suggestions if it makes more sense to call it something else.

### Alternate Designs

I considered _changing_ existing scopes to accomplish this rather than adding a new one, but decided not to so that this change won't break any existing scopes or colour themes—this PR is completely backwards-compatible.

### Benefits

Among other things, this will allow users of Atom and VS Code to style typehints differently based on whether they are class names or primitive types.

Here's VS Code right now:

<img width="598" alt="Screen Shot 2020-04-11 at 9 05 46 PM" src="https://user-images.githubusercontent.com/18192441/79287023-70bc4b00-7e90-11ea-8a07-164768d1a459.png">

Note that `Request` is the name of a class imported at the top of the file. It's purple just like `bool`, and before this PR **there was no way to change this or style primitive typehints and class names differently**.

For comparison, here's Sublime:

<img width="594" alt="Screen Shot 2020-04-11 at 9 06 20 PM" src="https://user-images.githubusercontent.com/18192441/79287027-76199580-7e90-11ea-9b44-50c257fe2c36.png">

Sublime's grammars and scopes are quite different, but the point is that the `Request` class typehint looks like a class name, and the `bool` primitive typehint looks like any other keyword.

### Possible Drawbacks

None that I can see.

### Applicable Issues

Closes #387. See also microsoft/vscode#95029.

It's worth noting that the styling thing is, confusingly, already possible for the `array` and `callable` types only, because they're tokenized different from any other typehints. I _think_ this is because their default arguments could contain parentheses (e.g. `array()`) but I would consider this a bug—right now `array` parameter typehints get the scope `meta.function.parameter.array.php`, but _**not**_ `meta.function.parameter.typehinted.php`, even though they are, of course, typehinted.