### PR TITLE
Fix meta.use end regex

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -124,7 +124,7 @@
     'beginCaptures':
       '0':
         'name': 'keyword.other.use.php'
-    'end': '(?<=})|(?=;)'
+    'end': '(?<=})|(?=;)|(?=\\?>)'
     'name': 'meta.use.php'
     'patterns': [
       {

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -285,12 +285,12 @@ describe 'PHP in HTML', ->
        <?php use Some\\Name ?>
        <article>
        '''
-      expect(lines[0][0]).toEqual value : '<?php', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.begin.php' ]
-      expect(lines[0][1]).toEqual value : ' ', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'source.php' ]
-      expect(lines[0][2]).toEqual value : 'use', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.use.php', 'keyword.other.use.php' ]
-      expect(lines[0][3]).toEqual value : ' ', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.use.php' ]
-      expect(lines[0][4]).toEqual value : 'Some', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.use.php', 'support.other.namespace.php' ]
-      expect(lines[0][5]).toEqual value : '\\', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.use.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php' ]
-      expect(lines[0][6]).toEqual value : 'Name', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.use.php', 'support.class.php' ]
-      expect(lines[0][8]).toEqual value : '?', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.end.php', 'source.php' ]
-      expect(lines[0][9]).toEqual value : '>', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.end.php' ]
+      expect(lines[0][0]).toEqual value: '<?php', scopes: ['text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.begin.php']
+      expect(lines[0][1]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php']
+      expect(lines[0][2]).toEqual value: 'use', scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.use.php', 'keyword.other.use.php']
+      expect(lines[0][3]).toEqual value: ' ', scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.use.php']
+      expect(lines[0][4]).toEqual value: 'Some', scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.use.php', 'support.other.namespace.php']
+      expect(lines[0][5]).toEqual value: '\\', scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.use.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(lines[0][6]).toEqual value: 'Name', scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.use.php', 'support.class.php']
+      expect(lines[0][8]).toEqual value: '?', scopes: ['text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.end.php', 'source.php']
+      expect(lines[0][9]).toEqual value: '>', scopes: ['text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.end.php']

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -279,3 +279,18 @@ describe 'PHP in HTML', ->
       '''
       for line in invalid.split /\n/
         expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()
+
+    it 'should tokenize <?php use Some\\Name ?>', ->
+      lines = grammar.tokenizeLines '''
+       <?php use Some\\Name ?>
+       <article>
+       '''
+      expect(lines[0][0]).toEqual value : '<?php', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.begin.php' ]
+      expect(lines[0][1]).toEqual value : ' ', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'source.php' ]
+      expect(lines[0][2]).toEqual value : 'use', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.use.php', 'keyword.other.use.php' ]
+      expect(lines[0][3]).toEqual value : ' ', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.use.php' ]
+      expect(lines[0][4]).toEqual value : 'Some', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.use.php', 'support.other.namespace.php' ]
+      expect(lines[0][5]).toEqual value : '\\', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.use.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php' ]
+      expect(lines[0][6]).toEqual value : 'Name', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.use.php', 'support.class.php' ]
+      expect(lines[0][8]).toEqual value : '?', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.end.php', 'source.php' ]
+      expect(lines[0][9]).toEqual value : '>', scopes : [ 'text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.end.php' ]


### PR DESCRIPTION
### Description of the Change
Add a positive lookahead regex to allow use of optional semicolon on the `use` operator without breaking the syntax highlighting.

### Alternate Designs

N/A

### Benefits
Allow usage of optional semicolon on the `use` operator

### Possible Drawbacks
Not that I can think of at the moment.

### Applicable Issues
Resolves https://github.com/atom/language-php/issues/364
