### PR TITLE
Non-capturing catches and multiple namespaced exceptions

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -372,7 +372,7 @@
           ([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)                 # Exception class
           ((?:\\s*\\|\\s*[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)*) # Optional additional exception classes
           \\s*
-          ((\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)           # Variable
+          ((\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?           # Variable
         '''
         'captures':
           '1':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -365,32 +365,37 @@
     'name': 'meta.catch.php'
     'patterns': [
       {
-        'include': '#namespace'
-      }
-      {
         'match': '''(?xi)
-          ([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)                 # Exception class
-          ((?:\\s*\\|\\s*[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)*) # Optional additional exception classes
+          ([a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)*) # union or single exception class
           \\s*
           ((\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?           # Variable
         '''
         'captures':
           '1':
-            'name': 'support.class.exception.php'
-          '2':
             'patterns': [
-              {
-                'match': '(?i)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*'
-                'name': 'support.class.exception.php'
-              }
               {
                 'match': '\\|'
                 'name': 'punctuation.separator.delimiter.php'
               }
+              {
+                'begin': '(?i)(?=[\\\\a-z_\\x{7f}-\\x{7fffffff}])'
+                'end': '''(?xi)
+                  ( [a-z_\\x{7f}-\\x{7fffffff}] [a-z0-9_\\x{7f}-\\x{7fffffff}]* )
+                  (?![a-z0-9_\\x{7f}-\\x{7fffffff}\\\\])
+                '''
+                'endCaptures':
+                  '1':
+                    'name': 'support.class.exception.php'
+                'patterns': [
+                  {
+                    'include': '#namespace'
+                  }
+                ]
+              }
             ]
-          '3':
+          '2':
             'name': 'variable.other.php'
-          '4':
+          '3':
             'name': 'punctuation.definition.variable.php'
       }
     ]

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1545,6 +1545,15 @@ describe 'PHP grammar', ->
       expect(tokens[14]).toEqual value: '{', scopes: ['source.php', 'punctuation.definition.begin.bracket.curly.php']
       expect(tokens[15]).toEqual value: '}', scopes: ['source.php', 'punctuation.definition.end.bracket.curly.php']
 
+    it 'tokenizes a catch block containing namespaced exception', ->
+      {tokens} = grammar.tokenizeLine 'try {} catch(\\Abc\\Exception $e) {}'
+
+      expect(tokens[5]).toEqual value: 'catch', scopes: ["source.php", "meta.catch.php", "keyword.control.exception.catch.php"]
+      expect(tokens[7]).toEqual value: '\\', scopes: ["source.php", "meta.catch.php", "support.other.namespace.php", "punctuation.separator.inheritance.php"]
+      expect(tokens[8]).toEqual value: 'Abc', scopes: ["source.php", "meta.catch.php", "support.other.namespace.php"]
+      expect(tokens[9]).toEqual value: '\\', scopes: ["source.php", "meta.catch.php", "support.other.namespace.php", "punctuation.separator.inheritance.php"]
+      expect(tokens[10]).toEqual value: 'Exception', scopes: ["source.php", "meta.catch.php", "support.class.exception.php"]
+
     it 'tokenizes a catch block containing multiple exceptions', ->
       {tokens} = grammar.tokenizeLine 'try {} catch(AException | BException | CException $e) {}'
 
@@ -1562,6 +1571,30 @@ describe 'PHP grammar', ->
       expect(tokens[19]).toEqual value: ')', scopes: ['source.php', 'meta.catch.php', 'punctuation.definition.parameters.end.bracket.round.php']
       expect(tokens[21]).toEqual value: '{', scopes: ['source.php', 'punctuation.definition.begin.bracket.curly.php']
       expect(tokens[22]).toEqual value: '}', scopes: ['source.php', 'punctuation.definition.end.bracket.curly.php']
+
+    it 'tokenizes a catch block containing multiple namespaced exceptions', ->
+      {tokens} = grammar.tokenizeLine 'try {} catch(\\Abc\\Exception | \\Test\\Exception | \\Error $e) {}'
+
+
+      expect(tokens[5]).toEqual value: 'catch', scopes: ["source.php", "meta.catch.php", "keyword.control.exception.catch.php"]
+      expect(tokens[6]).toEqual value: '(', scopes: ["source.php", "meta.catch.php", "punctuation.definition.parameters.begin.bracket.round.php"]
+      expect(tokens[7]).toEqual value: '\\', scopes: ["source.php", "meta.catch.php", "support.other.namespace.php", "punctuation.separator.inheritance.php"]
+      expect(tokens[8]).toEqual value: 'Abc', scopes: ["source.php", "meta.catch.php", "support.other.namespace.php"]
+      expect(tokens[9]).toEqual value: '\\', scopes: ["source.php", "meta.catch.php", "support.other.namespace.php", "punctuation.separator.inheritance.php"]
+      expect(tokens[10]).toEqual value: 'Exception', scopes: ["source.php", "meta.catch.php", "support.class.exception.php"]
+      expect(tokens[11]).toEqual value: ' ', scopes: ["source.php", "meta.catch.php"]
+      expect(tokens[12]).toEqual value: '|', scopes: ["source.php", "meta.catch.php", "punctuation.separator.delimiter.php"]
+      expect(tokens[13]).toEqual value: ' ', scopes: ["source.php", "meta.catch.php"]
+      expect(tokens[14]).toEqual value: '\\', scopes: ["source.php", "meta.catch.php", "support.other.namespace.php", "punctuation.separator.inheritance.php"]
+      expect(tokens[15]).toEqual value: 'Test', scopes: ["source.php", "meta.catch.php", "support.other.namespace.php"]
+      expect(tokens[16]).toEqual value: '\\', scopes: ["source.php", "meta.catch.php", "support.other.namespace.php", "punctuation.separator.inheritance.php"]
+      expect(tokens[17]).toEqual value: 'Exception', scopes: ["source.php", "meta.catch.php", "support.class.exception.php"]
+      expect(tokens[18]).toEqual value: ' ', scopes: ["source.php", "meta.catch.php"]
+      expect(tokens[19]).toEqual value: '|', scopes: ["source.php", "meta.catch.php", "punctuation.separator.delimiter.php"]
+      expect(tokens[20]).toEqual value: ' ', scopes: ["source.php", "meta.catch.php"]
+      expect(tokens[21]).toEqual value: '\\', scopes: ["source.php", "meta.catch.php", "support.other.namespace.php", "punctuation.separator.inheritance.php"]
+      expect(tokens[22]).toEqual value: 'Error', scopes: ["source.php", "meta.catch.php", "support.class.exception.php"]
+      expect(tokens[26]).toEqual value: ')', scopes: ["source.php", "meta.catch.php", "punctuation.definition.parameters.end.bracket.round.php"]
 
     it 'tokenizes non-capturing catch block', ->
       {tokens} = grammar.tokenizeLine 'try {} catch (Exception) {}'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1563,6 +1563,16 @@ describe 'PHP grammar', ->
       expect(tokens[21]).toEqual value: '{', scopes: ['source.php', 'punctuation.definition.begin.bracket.curly.php']
       expect(tokens[22]).toEqual value: '}', scopes: ['source.php', 'punctuation.definition.end.bracket.curly.php']
 
+    it 'tokenizes non-capturing catch block', ->
+      {tokens} = grammar.tokenizeLine 'try {} catch (Exception) {}'
+
+      expect(tokens[5]).toEqual value: 'catch', scopes: ["source.php", "meta.catch.php", "keyword.control.exception.catch.php"]
+      expect(tokens[7]).toEqual value: '(', scopes: ["source.php", "meta.catch.php", "punctuation.definition.parameters.begin.bracket.round.php"]
+      expect(tokens[8]).toEqual value: 'Exception', scopes: ["source.php", "meta.catch.php", "support.class.exception.php"]
+      expect(tokens[9]).toEqual value: ')', scopes: ["source.php", "meta.catch.php", "punctuation.definition.parameters.end.bracket.round.php"]
+      expect(tokens[11]).toEqual value: '{', scopes: ["source.php", "punctuation.definition.begin.bracket.curly.php"]
+      expect(tokens[12]).toEqual value: '}', scopes: ["source.php", "punctuation.definition.end.bracket.curly.php"]
+
   describe 'numbers', ->
     it 'tokenizes hexadecimals', ->
       {tokens} = grammar.tokenizeLine '0x1D306'


### PR DESCRIPTION
This is part of #395 

RFC: https://wiki.php.net/rfc/non-capturing_catches

There is no backward incompatible changes, safe to merge

Also fixes partially #390 (1st point)