### PR TITLE
Support UTF-8 characters in namespaces and class names

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -896,8 +896,11 @@
   'class-name':
     'patterns': [
       {
-        'begin': '(?i)(?=\\\\?[a-z_0-9]+\\\\)'
-        'end': '(?i)([a-z_][a-z_0-9]*)?(?![a-z0-9_\\\\])'
+        'begin': '(?i)(?=\\\\?[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*\\\\)'
+        'end': '''(?xi)
+          ( [a-z_\\x{7f}-\\x{7fffffff}] [a-z0-9_\\x{7f}-\\x{7fffffff}]* )?
+          (?![a-z0-9_\\x{7f}-\\x{7fffffff}\\\\])
+        '''
         'endCaptures':
           '1':
             'name': 'support.class.php'
@@ -911,8 +914,11 @@
         'include': '#class-builtin'
       }
       {
-        'begin': '(?=[\\\\a-zA-Z_])'
-        'end': '(?i)([a-z_][a-z_0-9]*)?(?![a-z0-9_\\\\])'
+        'begin': '(?i)(?=[\\\\a-z_\\x{7f}-\\x{7fffffff}])'
+        'end': '''(?xi)
+          ( [a-z_\\x{7f}-\\x{7fffffff}] [a-z0-9_\\x{7f}-\\x{7fffffff}]* )?
+          (?![a-z0-9_\\x{7f}-\\x{7fffffff}\\\\])
+        '''
         'endCaptures':
           '1':
             'name': 'support.class.php'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -379,6 +379,17 @@ describe 'PHP grammar', ->
       expect(tokens[6]).toEqual value: 'Three', scopes: ['source.php', 'meta.namespace.php', 'entity.name.type.namespace.php']
       expect(tokens[7]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
+    it 'tokenizes namespace with emojis', ->
+      {tokens} = grammar.tokenizeLine 'namespace \\Emojis\\🐘;'
+
+      expect(tokens[0]).toEqual value: 'namespace', scopes: ["source.php", "meta.namespace.php", "keyword.other.namespace.php"]
+      expect(tokens[1]).toEqual value: ' ', scopes: ["source.php", "meta.namespace.php"]
+      expect(tokens[2]).toEqual value: '\\', scopes: ["source.php", "meta.namespace.php", "entity.name.type.namespace.php", "punctuation.separator.inheritance.php"]
+      expect(tokens[3]).toEqual value: 'Emojis', scopes: ["source.php", "meta.namespace.php", "entity.name.type.namespace.php"]
+      expect(tokens[4]).toEqual value: '\\', scopes: ["source.php", "meta.namespace.php", "entity.name.type.namespace.php", "punctuation.separator.inheritance.php"]
+      expect(tokens[5]).toEqual value: '🐘', scopes: ["source.php", "meta.namespace.php", "entity.name.type.namespace.php"]
+      expect(tokens[6]).toEqual value: ';', scopes: ["source.php", "punctuation.terminator.expression.php"]
+
     it 'tokenizes bracketed namespaces', ->
       lines = grammar.tokenizeLines '''
         namespace Test {
@@ -487,6 +498,19 @@ describe 'PHP grammar', ->
       expect(tokens[5]).toEqual value: '\\', scopes: ['source.php', 'meta.use.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
       expect(tokens[6]).toEqual value: 'NSname', scopes: ['source.php', 'meta.use.php', 'support.class.php']
       expect(tokens[7]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+
+    it 'tokenizes use statement with emojis', ->
+      {tokens} = grammar.tokenizeLine 'use \\Emojis\\🐘\\Big🐘;'
+
+      expect(tokens[0]).toEqual value: 'use', scopes: ["source.php", "meta.use.php", "keyword.other.use.php"]
+      expect(tokens[1]).toEqual value: ' ', scopes: ["source.php", "meta.use.php"]
+      expect(tokens[2]).toEqual value: '\\', scopes: ["source.php", "meta.use.php", "support.other.namespace.php", "punctuation.separator.inheritance.php"]
+      expect(tokens[3]).toEqual value: 'Emojis', scopes: ["source.php", "meta.use.php", "support.other.namespace.php"]
+      expect(tokens[4]).toEqual value: '\\', scopes: ["source.php", "meta.use.php", "support.other.namespace.php", "punctuation.separator.inheritance.php"]
+      expect(tokens[5]).toEqual value: '🐘', scopes: ["source.php", "meta.use.php", "support.other.namespace.php"]
+      expect(tokens[6]).toEqual value: '\\', scopes: ["source.php", "meta.use.php", "support.other.namespace.php", "punctuation.separator.inheritance.php"]
+      expect(tokens[7]).toEqual value: 'Big🐘', scopes: ["source.php", "meta.use.php", "support.class.php"]
+      expect(tokens[8]).toEqual value: ';', scopes: ["source.php", "punctuation.terminator.expression.php"]
 
     it 'tokenizes multiline use statements', ->
       lines = grammar.tokenizeLines '''


### PR DESCRIPTION
### Description of the Change

Added support for all allowed characters in namespaces and class names. https://www.php.net/manual/en/language.oop5.basic.php / https://3v4l.org/0LXlW

### Possible Drawbacks

none

### Applicable Issues

none