### PR TITLE
Update type hints

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -575,7 +575,7 @@
           {
             # static is only allowed in return of methods
             'match': '\\b(static)\\b',
-            'name': 'support.class.php'
+            'name': 'storage.type.php'
           }
           {
             'include': '#php-types'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -448,20 +448,28 @@
                 'name': 'storage.modifier.reference.php'
               '3':
                 'name': 'punctuation.definition.variable.php'
-            'match': '(?i)((&)?\\s*(\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)\\s*(?=,|\\))'
+            'match': '(?i)((?:(&)\\s*)?(\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)\\s*(?=,|\\))'
             'name': 'meta.function.closure.use.php'
           }
         ]
       }
       {
-        'match': '(:)\\s*(\\?)?\\s*((?:\\\\?[a-zA-Z_\\x{7f}-\\x{7fffffff}][a-zA-Z0-9_\\x{7f}-\\x{7fffffff}]*)+)'
+        'match': '''(?xi)
+          (:)\\s*
+          (
+            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
+            [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
+          )
+        '''
         'captures':
           '1':
             'name': 'keyword.operator.return-value.php'
           '2':
-            'name': 'keyword.operator.nullable-type.php'
-          '3':
-            'name': 'storage.type.php'
+            'patterns': [
+              {
+                'include': '#php-types'
+              }
+            ]
       }
     ]
   }
@@ -477,7 +485,7 @@
     'name': 'meta.function.closure.php'
     'patterns': [
       {
-        'begin': '(&)?\\s*(\\()'
+        'begin': '(?:(&)\\s*)?(\\()'
         'beginCaptures':
           '1':
             'name': 'storage.modifier.reference.php'
@@ -495,14 +503,22 @@
         ]
       }
       {
-        'match': '(:)\\s*(\\?)?\\s*((?:\\\\?[a-zA-Z_\\x{7f}-\\x{7fffffff}][a-zA-Z0-9_\\x{7f}-\\x{7fffffff}]*)+)\\s*'
+        'match': '''(?xi)
+          (:)\\s*
+          (
+            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
+            [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
+          )
+        '''
         'captures':
           '1':
             'name': 'keyword.operator.return-value.php'
           '2':
-            'name': 'keyword.operator.nullable-type.php'
-          '3':
-            'name': 'storage.type.php'
+            'patterns': [
+              {
+                'include': '#php-types'
+              }
+            ]
       }
     ]
   }
@@ -536,16 +552,28 @@
       '6':
         'name': 'punctuation.definition.parameters.begin.bracket.round.php'
     'contentName': 'meta.function.parameters.php'
-    'end': '(\\))(?:\\s*(:)\\s*(\\?)?\\s*((?:\\\\?[a-zA-Z_\\x{7f}-\\x{7fffffff}][a-zA-Z0-9_\\x{7f}-\\x{7fffffff}]*)+))?'
+    'end': '''(?xi)
+      (\\)) (?: \\s* (:) \\s* (
+        (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
+        [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
+      ) )?
+    '''
     'endCaptures':
       '1':
         'name': 'punctuation.definition.parameters.end.bracket.round.php'
       '2':
         'name': 'keyword.operator.return-value.php'
       '3':
-        'name': 'keyword.operator.nullable-type.php'
-      '4':
-        'name': 'storage.type.php'
+        'patterns': [
+          {
+            # static is only allowed in return of methods
+            'match': '\\b(static)\\b',
+            'name': 'support.class.php'
+          }
+          {
+            'include': '#php-types'
+          }
+        ]
     'name': 'meta.function.php'
     'patterns': [
       {
@@ -556,10 +584,11 @@
   {
     'match': '''(?xi)
       ((?:(?:public|private|protected|static)(?:\\s+|(?=\\?)))+)                     # At least one modifier
-      (?:(\\?)?\\s*                                                                  # Optional nullable
-        (\\\\?(?:[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*\\\\)*)   # Optional namespace
-        ([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*))?               # Typehinted class name
-      \\s+((\\$)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)          # Variable name
+      (
+        (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
+        [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
+      )?
+      \\s+ ((\\$)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)          # Variable name
     '''
     'captures':
       '1':
@@ -570,24 +599,14 @@
           }
         ]
       '2':
-        'name': 'keyword.operator.nullable-type.php'
-      '3':
-        'name': 'support.other.namespace.php'
         'patterns': [
           {
-            'match': '(?i)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*'
-            'name': 'storage.type.php'
-          }
-          {
-            'match': '\\\\'
-            'name': 'punctuation.separator.inheritance.php'
+            'include': '#php-types'
           }
         ]
-      '4':
-        'name': 'storage.type.php'
-      '5':
+      '3':
         'name': 'variable.other.php'
-      '6':
+      '4':
         'name': 'punctuation.definition.variable.php'
   }
   {
@@ -642,7 +661,7 @@
         'name': 'punctuation.definition.storage-type.end.bracket.round.php'
   }
   {
-    'match': '(?i)\\b(array|real|double|float|int(eger)?|bool(ean)?|string|class|var|function|interface|trait|parent|self|object)\\b'
+    'match': '(?i)\\b(array|real|double|float|int(eger)?|bool(ean)?|string|class|var|function|interface|trait|parent|self|object|mixed)\\b'
     'name': 'storage.type.php'
   }
   {
@@ -1206,123 +1225,55 @@
         'name': 'punctuation.separator.delimiter.php'
       }
       {
-        'begin': '''(?xi)
-          (?:(\\?)\\s*)?(array)                                              # Typehint
-          \\s+((&)?\\s*(\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable name with possible reference
-          \\s*(=)\\s*(array)\\s*(\\()                                        # Default value
-        '''
-        'beginCaptures':
-          '1':
-            'name': 'keyword.operator.nullable-type.php'
-          '2':
-            'name': 'storage.type.php'
-          '3':
-            'name': 'variable.other.php'
-          '4':
-            'name': 'storage.modifier.reference.php'
-          '5':
-            'name': 'punctuation.definition.variable.php'
-          '6':
-            'name': 'keyword.operator.assignment.php'
-          '7':
-            'name': 'support.function.construct.php'
-          '8':
-            'name': 'punctuation.definition.array.begin.bracket.round.php'
-        'contentName': 'meta.array.php'
-        'end': '\\)'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.array.end.bracket.round.php'
-        'name': 'meta.function.parameter.array.php'
-        'patterns': [
-          {
-            'include': '#comments'
-          }
-          {
-            'include': '#strings'
-          }
-          {
-            'include': '#numbers'
-          }
-        ]
-      }
-      {
+        # Variadic
         'match': '''(?xi)
-          (?:(\\?)\\s*)?(array|callable)                                     # Typehint
-          \\s+((&)?\\s*(\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable name with possible reference
-          (?:                                                                # Optional default value
-            \\s*(=)\\s*
-            (?:
-              (null)
-              |
-              (\\[)((?>[^\\[\\]]+|\\[\\g<8>\\])*)(\\])
-              |((?:\\S*?\\(\\))|(?:\\S*?))
-            )
-          )?
-          \\s*(?=,|\\)|/[/*]|\\#|$) # A closing parentheses (end of argument list) or a comma or a comment
+          (?: (
+            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
+            [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
+          ) \\s+ )?
+          ((?:(&)\\s*)?(\\.\\.\\.)(\\$)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable name with possible reference
+          (?=\\s*(?:,|\\)|/[/*]|\\#|$)) # A closing parentheses (end of argument list) or a comma or a comment
         '''
-        'name': 'meta.function.parameter.array.php'
         'captures':
           '1':
-            'name': 'keyword.operator.nullable-type.php'
-          '2':
-            'name': 'storage.type.php'
-          '3':
-            'name': 'variable.other.php'
-          '4':
-            'name': 'storage.modifier.reference.php'
-          '5':
-            'name': 'punctuation.definition.variable.php'
-          '6':
-            'name': 'keyword.operator.assignment.php'
-          '7':
-            'name': 'constant.language.php'
-          '8':
-            'name': 'punctuation.section.array.begin.php'
-          '9':
             'patterns': [
               {
-                'include': '#parameter-default-types'
+                'include': '#php-types'
               }
             ]
-          '10':
-            'name': 'punctuation.section.array.end.php'
-          '11':
-            'name': 'invalid.illegal.non-null-typehinted.php'
+          '2':
+            'name': 'variable.other.php'
+          '3':
+            'name': 'storage.modifier.reference.php'
+          '4':
+            'name': 'keyword.operator.variadic.php'
+          '5':
+            'name': 'punctuation.definition.variable.php'
+        'name': 'meta.function.parameter.variadic.php'
       }
       {
+        # Typehinted
         'begin': '''(?xi)
-          (?:(\\?)\\s*)?
-          (\\\\?(?:[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*\\\\)*)                 # Optional namespace
-          ([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)                               # Typehinted class name
-          \\s+((&)?\\s*(\\.\\.\\.)?(\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable name with possible reference
+          (
+            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
+            [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
+          )
+          \\s+ ((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable name with possible reference
         '''
         'beginCaptures':
           '1':
-            'name': 'keyword.operator.nullable-type.php'
-          '2':
-            'name': 'support.other.namespace.php'
             'patterns': [
               {
-                'match': '(?i)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*'
-                'name': 'storage.type.php'
-              }
-              {
-                'match': '\\\\'
-                'name': 'punctuation.separator.inheritance.php'
+                'include': '#php-types'
               }
             ]
-          '3':
-            'name': 'storage.type.php'
-          '4':
+          '2':
             'name': 'variable.other.php'
-          '5':
+          '3':
             'name': 'storage.modifier.reference.php'
-          '6':
-            'name': 'keyword.operator.variadic.php'
-          '7':
+          '4':
             'name': 'punctuation.definition.variable.php'
-        'end': '(?=,|\\)|/[/*]|\\#)'
+        'end': '(?=\\s*(?:,|\\)|/[/*]|\\#))'
         'name': 'meta.function.parameter.typehinted.php'
         'patterns': [
           {
@@ -1330,36 +1281,33 @@
             'beginCaptures':
               '0':
                 'name': 'keyword.operator.assignment.php'
-            'end': '(?=,|\\)|/[/*]|\\#)'
+            'end': '(?=\\s*(?:,|\\)|/[/*]|\\#))'
             'patterns': [
               {
-                'include': '$self'
+                'include': '#parameter-default-types'
               }
             ]
           }
         ]
       }
       {
+        'match': '''(?xi)
+          ((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable name with possible reference
+          (?=\\s*(?:,|\\)|/[/*]|\\#|$)) # A closing parentheses (end of argument list) or a comma or a comment
+        '''
         'captures':
           '1':
             'name': 'variable.other.php'
           '2':
             'name': 'storage.modifier.reference.php'
           '3':
-            'name': 'keyword.operator.variadic.php'
-          '4':
             'name': 'punctuation.definition.variable.php'
-        'match': '''(?xi)
-          ((&)?\\s*(\\.\\.\\.)?(\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable name with possible reference
-          \\s*(?=,|\\)|/[/*]|\\#|$) # A closing parentheses (end of argument list) or a comma or a comment
-        '''
         'name': 'meta.function.parameter.no-default.php'
       }
       {
         'begin': '''(?xi)
-          ((&)?\\s*(\\.\\.\\.)?(\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable name with possible reference
+          ((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable name with possible reference
           \\s*(=)\\s*
-          (?:(\\[)((?>[^\\[\\]]+|\\[\\g<6>\\])*)(\\]))?                              # Optional default type
         '''
         'beginCaptures':
           '1':
@@ -1367,22 +1315,10 @@
           '2':
             'name': 'storage.modifier.reference.php'
           '3':
-            'name': 'keyword.operator.variadic.php'
-          '4':
             'name': 'punctuation.definition.variable.php'
-          '5':
+          '4':
             'name': 'keyword.operator.assignment.php'
-          '6':
-            'name': 'punctuation.section.array.begin.php'
-          '7':
-            'patterns': [
-              {
-                'include': '#parameter-default-types'
-              }
-            ]
-          '8':
-            'name': 'punctuation.section.array.end.php'
-        'end': '(?=,|\\)|/[/*]|\\#)'
+        'end': '(?=\\s*(?:,|\\)|/[/*]|\\#))'
         'name': 'meta.function.parameter.default.php'
         'patterns': [
           {
@@ -2153,6 +2089,30 @@
         'match': '(?i)(->)((\\$+)?[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?'
       }
     ]
+  'php-types':
+    'patterns': [
+      {
+        'match': '\\?'
+        'name': 'keyword.operator.nullable-type.php'
+      }
+      {
+        'match': '\\|'
+        'name': 'punctuation.separator.delimiter.php'
+      }
+      {
+        # false is allowed in unions
+        'match': '(?i)\\b(null|int|float|bool|string|array|object|callable|iterable|false|mixed)\\b',
+        'name': 'storage.type.php'
+      }
+      {
+        # static is only allowed in return of methods
+        'match': '(?i)\\b(parent|self)\\b',
+        'name': 'storage.type.php'
+      }
+      {
+        'include': '#class-name'
+      }
+    ]
   'parameter-default-types':
     'patterns': [
       {
@@ -2194,6 +2154,21 @@
         'patterns': [
           {
             'include': '#parameter-default-types'
+          }
+        ]
+      }
+      {
+        'begin': '\\['
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.array.begin.php'
+        'end': '\\]|(?=\\?>)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.array.end.php'
+        'patterns': [
+          {
+            'include': '$self'
           }
         ]
       }
@@ -2295,7 +2270,7 @@
           {
             'match': '''(?x)\\b
               (string|integer|int|boolean|bool|float|double|object|mixed
-              |array|resource|void|null|callback|false|true|self)\\b
+              |array|resource|void|null|callback|false|true|self|static)\\b
             '''
             'name': 'keyword.other.type.php'
           }

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -464,6 +464,7 @@
             (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
             [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
           )
+          (?=\\s*(?:{|/[/*]|\\#|$))
         '''
         'captures':
           '1':
@@ -513,6 +514,7 @@
             (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
             [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
           )
+          (?=\\s*(?:=>|/[/*]|\\#|$))
         '''
         'captures':
           '1':
@@ -561,6 +563,7 @@
         (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
         [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
       ) )?
+      (?=\\s*(?:{|/[/*]|\\#|$))
     '''
     'endCaptures':
       '1':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -529,6 +529,96 @@
     ]
   }
   {
+    # constructor
+    'begin': '''(?x)
+      ((?:(?:final|abstract|public|private|protected)\\s+)*)
+      (function)\\s+(__construct)
+      \\s*(\\()
+    '''
+    'beginCaptures':
+      '1':
+        'patterns': [
+          {
+            'match': 'final|abstract|public|private|protected'
+            'name': 'storage.modifier.php'
+          }
+        ]
+      '2':
+        'name': 'storage.type.function.php'
+      '3':
+        'name': 'support.function.constructor.php'
+      '4':
+        'name': 'punctuation.definition.parameters.begin.bracket.round.php'
+    'contentName': 'meta.function.parameters.php'
+    'end': '''(?xi)
+      (\\)) \\s* ( : \\s*
+        (?:\\?\\s*)? (?!\\s) [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\\\s\\|]+ (?<!\\s)
+      )?
+      (?=\\s*(?:{|/[/*]|\\#|$))
+    '''
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.parameters.end.bracket.round.php'
+      '2':
+        'name': 'invalid.illegal.return-type.php'
+    'name': 'meta.function.php'
+    'patterns': [
+      {
+        'include': '#comments'
+      }
+      {
+        'match': ','
+        'name': 'punctuation.separator.delimiter.php'
+      }
+      {
+        # Constructor Property Promotion
+        'begin': '''(?xi)
+          (public|private|protected) \\s+
+          (?: (
+            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
+            [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
+          ) \\s+ )?
+          ((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable name with possible reference
+        '''
+        'beginCaptures':
+          '1':
+            'name': 'storage.modifier.php'
+          '2':
+            'patterns': [
+              {
+                'include': '#php-types'
+              }
+            ]
+          '3':
+            'name': 'variable.other.php'
+          '4':
+            'name': 'storage.modifier.reference.php'
+          '5':
+            'name': 'punctuation.definition.variable.php'
+        'end': '(?=\\s*(?:,|\\)|/[/*]|\\#))'
+        'name': 'meta.function.parameter.promoted-property.php'
+        'patterns': [
+          {
+            'begin': '='
+            'beginCaptures':
+              '0':
+                'name': 'keyword.operator.assignment.php'
+            'end': '(?=\\s*(?:,|\\)|/[/*]|\\#))'
+            'patterns': [
+              {
+                'include': '#parameter-default-types'
+              }
+            ]
+          }
+        ]
+      }
+      {
+        'include': '#function-parameters'
+      }
+    ]
+  }
+  {
+    # method
     'begin': '''(?x)
       ((?:(?:final|abstract|public|private|protected|static)\\s+)*)
       (function)\\s+

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -439,7 +439,12 @@
         'endCaptures':
           '0':
             'name': 'punctuation.definition.parameters.end.bracket.round.php'
+        'name': 'meta.function.closure.use.php'
         'patterns': [
+          {
+            'match': ','
+            'name': 'punctuation.separator.delimiter.php'
+          }
           {
             'captures':
               '1':
@@ -449,7 +454,6 @@
               '3':
                 'name': 'punctuation.definition.variable.php'
             'match': '(?i)((?:(&)\\s*)?(\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)\\s*(?=,|\\))'
-            'name': 'meta.function.closure.use.php'
           }
         ]
       }

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -738,6 +738,62 @@ describe 'PHP grammar', ->
         expect(lines[3][13]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
         expect(lines[3][14]).toEqual value: 'c2', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php"]
 
+    describe 'methods', ->
+      it 'tokenizes basic method', ->
+        lines = grammar.tokenizeLines '''
+          class Test {
+            public function Run($a, $b = false){}
+          }
+        '''
+
+        expect(lines[1][1]).toEqual value: 'public', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'storage.modifier.php']
+        expect(lines[1][3]).toEqual value: 'function', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'storage.type.function.php']
+        expect(lines[1][5]).toEqual value: 'Run', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'entity.name.function.php']
+        expect(lines[1][6]).toEqual value: '(', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
+        expect(lines[1][7]).toEqual value: '$', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.no-default.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(lines[1][8]).toEqual value: 'a', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.no-default.php', 'variable.other.php']
+        expect(lines[1][9]).toEqual value: ',', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'punctuation.separator.delimiter.php']
+        expect(lines[1][11]).toEqual value: '$', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.default.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(lines[1][12]).toEqual value: 'b', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.default.php', 'variable.other.php']
+        expect(lines[1][14]).toEqual value: '=', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.default.php', 'keyword.operator.assignment.php']
+        expect(lines[1][16]).toEqual value: 'false', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.default.php', 'constant.language.php']
+
+      it 'tokenizes typehinted method', ->
+        lines = grammar.tokenizeLines '''
+          class Test {
+            public function Run(int $a, ? ClassB $b, self | bool $c = false) : float | ClassA {}
+          }
+        '''
+
+        expect(lines[1][7]).toEqual value: 'int', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+        expect(lines[1][9]).toEqual value: '$', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(lines[1][10]).toEqual value: 'a', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+        expect(lines[1][13]).toEqual value: '?', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'keyword.operator.nullable-type.php']
+        expect(lines[1][15]).toEqual value: 'ClassB', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.class.php']
+        expect(lines[1][17]).toEqual value: '$', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(lines[1][18]).toEqual value: 'b', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+        expect(lines[1][21]).toEqual value: 'self', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+        expect(lines[1][23]).toEqual value: '|', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'punctuation.separator.delimiter.php']
+        expect(lines[1][25]).toEqual value: 'bool', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+        expect(lines[1][27]).toEqual value: '$', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(lines[1][28]).toEqual value: 'c', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+        expect(lines[1][30]).toEqual value: '=', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'keyword.operator.assignment.php']
+        expect(lines[1][32]).toEqual value: 'false', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'constant.language.php']
+        expect(lines[1][35]).toEqual value: ':', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'keyword.operator.return-value.php']
+        expect(lines[1][37]).toEqual value: 'float', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'storage.type.php']
+        expect(lines[1][39]).toEqual value: '|', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'punctuation.separator.delimiter.php']
+        expect(lines[1][41]).toEqual value: 'ClassA', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'support.class.php']
+
+      it 'tokenizes static return type', ->
+        lines = grammar.tokenizeLines '''
+          class Test {
+            public function Me() :static {}
+          }
+        '''
+
+        expect(lines[1][9]).toEqual value: ':', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'keyword.operator.return-value.php']
+        expect(lines[1][10]).toEqual value: 'static', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'storage.type.php']
+
     describe 'use statements', ->
       it 'tokenizes basic use statements', ->
         lines = grammar.tokenizeLines '''
@@ -1074,6 +1130,38 @@ describe 'PHP grammar', ->
       expect(tokens[23]).toEqual value: 'null', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'constant.language.php']
       expect(tokens[24]).toEqual value: ')', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
 
+    it 'tokenizes union types in function parameters', ->
+      {tokens} = grammar.tokenizeLine 'function test(int|false $a){}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ['source.php', 'meta.function.php', 'storage.type.function.php']
+      expect(tokens[2]).toEqual value: 'test', scopes: ['source.php', 'meta.function.php', 'entity.name.function.php']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
+      expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+      expect(tokens[5]).toEqual value: '|', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'punctuation.separator.delimiter.php']
+      expect(tokens[6]).toEqual value: 'false', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+      expect(tokens[7]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
+      expect(tokens[8]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[9]).toEqual value: 'a', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+      expect(tokens[10]).toEqual value: ')', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
+
+      {tokens} = grammar.tokenizeLine 'function test(\\Abc\\ClassA | mixed $a){}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ['source.php', 'meta.function.php', 'storage.type.function.php']
+      expect(tokens[2]).toEqual value: 'test', scopes: ['source.php', 'meta.function.php', 'entity.name.function.php']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
+      expect(tokens[4]).toEqual value: '\\', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[5]).toEqual value: 'Abc', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php']
+      expect(tokens[6]).toEqual value: '\\', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[7]).toEqual value: 'ClassA', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.class.php']
+      expect(tokens[8]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
+      expect(tokens[9]).toEqual value: '|', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'punctuation.separator.delimiter.php']
+      expect(tokens[10]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
+      expect(tokens[11]).toEqual value: 'mixed', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+      expect(tokens[12]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
+      expect(tokens[13]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[14]).toEqual value: 'a', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+      expect(tokens[15]).toEqual value: ')', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
+
     it 'tokenizes trailing comma in function parameters', ->
       {tokens} = grammar.tokenizeLine 'function abc($a, $b,){}'
 
@@ -1117,6 +1205,17 @@ describe 'PHP grammar', ->
       expect(tokens[8]).toEqual value: '?', scopes: ['source.php', 'meta.function.php', 'keyword.operator.nullable-type.php']
       expect(tokens[9]).toEqual value: '   ', scopes: ['source.php', 'meta.function.php']
       expect(tokens[10]).toEqual value: 'Client', scopes: ['source.php', 'meta.function.php', 'support.class.php']
+
+    it 'tokenizes union return types', ->
+      {tokens} = grammar.tokenizeLine 'function test() : \\ClassB | null {}'
+
+      expect(tokens[6]).toEqual value: ':', scopes: ['source.php', 'meta.function.php', 'keyword.operator.return-value.php']
+      expect(tokens[8]).toEqual value: '\\', scopes: ['source.php', 'meta.function.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[9]).toEqual value: 'ClassB', scopes: ['source.php', 'meta.function.php', 'support.class.php']
+      expect(tokens[10]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php']
+      expect(tokens[11]).toEqual value: '|', scopes: ['source.php', 'meta.function.php', 'punctuation.separator.delimiter.php']
+      expect(tokens[12]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php']
+      expect(tokens[13]).toEqual value: 'null', scopes: ['source.php', 'meta.function.php', 'storage.type.php']
 
     it 'tokenizes function names with characters other than letters or numbers', ->
       # Char 160 is hex 0xA0, which is between 0x7F and 0xFF, making it a valid PHP identifier

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -794,6 +794,51 @@ describe 'PHP grammar', ->
         expect(lines[1][9]).toEqual value: ':', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'keyword.operator.return-value.php']
         expect(lines[1][10]).toEqual value: 'static', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'storage.type.php']
 
+      it 'tokenizes basic promoted properties in constructor', ->
+        lines = grammar.tokenizeLines '''
+          class Test {
+            public function __construct(public $a, public int $b = 1) {}
+          }
+        '''
+
+        expect(lines[1][5]).toEqual value: '__construct', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'support.function.constructor.php']
+        expect(lines[1][7]).toEqual value: 'public', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.promoted-property.php', 'storage.modifier.php']
+        expect(lines[1][9]).toEqual value: '$', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.promoted-property.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(lines[1][10]).toEqual value: 'a', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.promoted-property.php', 'variable.other.php']
+        expect(lines[1][13]).toEqual value: 'public', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.promoted-property.php', 'storage.modifier.php']
+        expect(lines[1][15]).toEqual value: 'int', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.promoted-property.php', 'storage.type.php']
+        expect(lines[1][17]).toEqual value: '$', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.promoted-property.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(lines[1][18]).toEqual value: 'b', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.promoted-property.php', 'variable.other.php']
+        expect(lines[1][20]).toEqual value: '=', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.promoted-property.php', 'keyword.operator.assignment.php']
+        expect(lines[1][22]).toEqual value: '1', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.promoted-property.php', 'constant.numeric.decimal.php']
+
+      it 'tokenizes promoted properties with parameters in constructor', ->
+
+        lines = grammar.tokenizeLines '''
+          class Test {
+            public function __construct(public bool $a, string $b) {}
+          }
+        '''
+
+        expect(lines[1][5]).toEqual value: '__construct', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'support.function.constructor.php']
+        expect(lines[1][7]).toEqual value: 'public', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.promoted-property.php', 'storage.modifier.php']
+        expect(lines[1][9]).toEqual value: 'bool', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.promoted-property.php', 'storage.type.php']
+        expect(lines[1][11]).toEqual value: '$', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.promoted-property.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(lines[1][12]).toEqual value: 'a', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.promoted-property.php', 'variable.other.php']
+        expect(lines[1][15]).toEqual value: 'string', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+        expect(lines[1][17]).toEqual value: '$', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(lines[1][18]).toEqual value: 'b', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+
+      it 'tokenizes constructor with illegal return type declaration', ->
+        lines = grammar.tokenizeLines '''
+          class Test {
+            public function __construct() : int {}
+          }
+        '''
+
+        expect(lines[1][5]).toEqual value: '__construct', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'support.function.constructor.php']
+        expect(lines[1][9]).toEqual value: ': int', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'meta.function.php', 'invalid.illegal.return-type.php']
+
     describe 'use statements', ->
       it 'tokenizes basic use statements', ->
         lines = grammar.tokenizeLines '''

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -685,9 +685,9 @@ describe 'PHP grammar', ->
         expect(lines[1][1]).toEqual value: 'public', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
         expect(lines[1][3]).toEqual value: '?', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "keyword.operator.nullable-type.php"]
         expect(lines[1][4]).toEqual value: '\\', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "support.other.namespace.php", "punctuation.separator.inheritance.php"]
-        expect(lines[1][5]).toEqual value: 'Space', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "support.other.namespace.php", "storage.type.php"]
+        expect(lines[1][5]).toEqual value: 'Space', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "support.other.namespace.php"]
         expect(lines[1][6]).toEqual value: '\\', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "support.other.namespace.php", "punctuation.separator.inheritance.php"]
-        expect(lines[1][7]).toEqual value: 'Test', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php"]
+        expect(lines[1][7]).toEqual value: 'Test', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "support.class.php"]
         expect(lines[1][9]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
         expect(lines[1][10]).toEqual value: 'c', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php"]
 
@@ -707,9 +707,9 @@ describe 'PHP grammar', ->
 
         expect(lines[2][1]).toEqual value: 'public', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.modifier.php"]
         expect(lines[2][3]).toEqual value: '\\', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "support.other.namespace.php", "punctuation.separator.inheritance.php"]
-        expect(lines[2][4]).toEqual value: 'Other', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "support.other.namespace.php", "storage.type.php"]
+        expect(lines[2][4]).toEqual value: 'Other', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "support.other.namespace.php"]
         expect(lines[2][5]).toEqual value: '\\', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "support.other.namespace.php", "punctuation.separator.inheritance.php"]
-        expect(lines[2][6]).toEqual value: 'Type', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php"]
+        expect(lines[2][6]).toEqual value: 'Type', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "support.class.php"]
         expect(lines[2][8]).toEqual value: '$', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php", "punctuation.definition.variable.php"]
         expect(lines[2][9]).toEqual value: 'b', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "variable.other.php"]
 
@@ -898,16 +898,16 @@ describe 'PHP grammar', ->
       expect(tokens[1]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php']
       expect(tokens[2]).toEqual value: 'array_test', scopes: ['source.php', 'meta.function.php', 'entity.name.function.php']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
-      expect(tokens[4]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'storage.type.php']
-      expect(tokens[5]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php']
-      expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'variable.other.php', 'punctuation.definition.variable.php']
-      expect(tokens[7]).toEqual value: 'value', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'variable.other.php']
-      expect(tokens[8]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php']
-      expect(tokens[9]).toEqual value: '=', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'keyword.operator.assignment.php']
-      expect(tokens[10]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php']
-      expect(tokens[11]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'support.function.construct.php']
-      expect(tokens[12]).toEqual value: '(', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'punctuation.definition.array.begin.bracket.round.php']
-      expect(tokens[13]).toEqual value: ')', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'punctuation.definition.array.end.bracket.round.php']
+      expect(tokens[4]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+      expect(tokens[5]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
+      expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[7]).toEqual value: 'value', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+      expect(tokens[8]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
+      expect(tokens[9]).toEqual value: '=', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'keyword.operator.assignment.php']
+      expect(tokens[10]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
+      expect(tokens[11]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'meta.array.php', 'support.function.construct.php']
+      expect(tokens[12]).toEqual value: '(', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'meta.array.php', 'punctuation.definition.array.begin.bracket.round.php']
+      expect(tokens[13]).toEqual value: ')', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'meta.array.php', 'punctuation.definition.array.end.bracket.round.php']
       expect(tokens[14]).toEqual value: ')', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
       expect(tokens[15]).toEqual value: ' ', scopes: ['source.php']
       expect(tokens[16]).toEqual value: '{', scopes: ['source.php', 'punctuation.definition.begin.bracket.curly.php']
@@ -916,23 +916,23 @@ describe 'PHP grammar', ->
     it 'tokenizes variadic arguments', ->
       {tokens} = grammar.tokenizeLine 'function test(...$value) {}'
 
-      expect(tokens[4]).toEqual value: '...', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.no-default.php', 'variable.other.php', 'keyword.operator.variadic.php']
-      expect(tokens[5]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.no-default.php', 'variable.other.php', 'punctuation.definition.variable.php']
-      expect(tokens[6]).toEqual value: 'value', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.no-default.php', 'variable.other.php']
+      expect(tokens[4]).toEqual value: '...', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'keyword.operator.variadic.php']
+      expect(tokens[5]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[6]).toEqual value: 'value', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php']
 
     it 'tokenizes variadic arguments and typehinted class name', ->
       {tokens} = grammar.tokenizeLine 'function test(class_name ...$value) {}'
 
-      expect(tokens[4]).toEqual value: 'class_name', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
-      expect(tokens[6]).toEqual value: '...', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'keyword.operator.variadic.php']
-      expect(tokens[7]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
-      expect(tokens[8]).toEqual value: 'value', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+      expect(tokens[4]).toEqual value: 'class_name', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'support.class.php']
+      expect(tokens[6]).toEqual value: '...', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'keyword.operator.variadic.php']
+      expect(tokens[7]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[8]).toEqual value: 'value', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php']
 
     it 'tokenizes nullable typehints', ->
       {tokens} = grammar.tokenizeLine 'function test(?class_name $value) {}'
 
       expect(tokens[4]).toEqual value: '?', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'keyword.operator.nullable-type.php']
-      expect(tokens[5]).toEqual value: 'class_name', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+      expect(tokens[5]).toEqual value: 'class_name', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.class.php']
       expect(tokens[7]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
       expect(tokens[8]).toEqual value: 'value', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
 
@@ -940,7 +940,7 @@ describe 'PHP grammar', ->
 
       expect(tokens[4]).toEqual value: '?', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'keyword.operator.nullable-type.php']
       expect(tokens[5]).toEqual value: '   ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
-      expect(tokens[6]).toEqual value: 'class_name', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+      expect(tokens[6]).toEqual value: 'class_name', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.class.php']
       expect(tokens[8]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
       expect(tokens[9]).toEqual value: 'value', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
 
@@ -948,33 +948,33 @@ describe 'PHP grammar', ->
       {tokens} = grammar.tokenizeLine 'function test(\\class_name $value) {}'
 
       expect(tokens[4]).toEqual value: '\\', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
-      expect(tokens[5]).toEqual value: 'class_name', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+      expect(tokens[5]).toEqual value: 'class_name', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.class.php']
       expect(tokens[7]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
 
       {tokens} = grammar.tokenizeLine 'function test(a\\class_name $value) {}'
 
-      expect(tokens[4]).toEqual value: 'a', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php', 'storage.type.php']
+      expect(tokens[4]).toEqual value: 'a', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php']
       expect(tokens[5]).toEqual value: '\\', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
-      expect(tokens[6]).toEqual value: 'class_name', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+      expect(tokens[6]).toEqual value: 'class_name', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.class.php']
       expect(tokens[8]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
 
       {tokens} = grammar.tokenizeLine 'function test(a\\b\\class_name $value) {}'
 
-      expect(tokens[4]).toEqual value: 'a', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php', 'storage.type.php']
+      expect(tokens[4]).toEqual value: 'a', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php']
       expect(tokens[5]).toEqual value: '\\', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
-      expect(tokens[6]).toEqual value: 'b', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php', 'storage.type.php']
+      expect(tokens[6]).toEqual value: 'b', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php']
       expect(tokens[7]).toEqual value: '\\', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
-      expect(tokens[8]).toEqual value: 'class_name', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+      expect(tokens[8]).toEqual value: 'class_name', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.class.php']
       expect(tokens[10]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
 
       {tokens} = grammar.tokenizeLine 'function test(\\a\\b\\class_name $value) {}'
 
       expect(tokens[4]).toEqual value: '\\', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
-      expect(tokens[5]).toEqual value: 'a', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php', 'storage.type.php']
+      expect(tokens[5]).toEqual value: 'a', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php']
       expect(tokens[6]).toEqual value: '\\', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
-      expect(tokens[7]).toEqual value: 'b', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php', 'storage.type.php']
+      expect(tokens[7]).toEqual value: 'b', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php']
       expect(tokens[8]).toEqual value: '\\', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
-      expect(tokens[9]).toEqual value: 'class_name', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+      expect(tokens[9]).toEqual value: 'class_name', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'support.class.php']
       expect(tokens[11]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
 
     it 'tokenizes default array type with short array value', ->
@@ -984,15 +984,15 @@ describe 'PHP grammar', ->
       expect(tokens[1]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php']
       expect(tokens[2]).toEqual value: 'array_test', scopes: ['source.php', 'meta.function.php', 'entity.name.function.php']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
-      expect(tokens[4]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'storage.type.php']
-      expect(tokens[5]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php']
-      expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'variable.other.php', 'punctuation.definition.variable.php']
-      expect(tokens[7]).toEqual value: 'value', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'variable.other.php']
-      expect(tokens[8]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php']
-      expect(tokens[9]).toEqual value: '=', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'keyword.operator.assignment.php']
-      expect(tokens[10]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php']
-      expect(tokens[11]).toEqual value: '[', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'punctuation.section.array.begin.php']
-      expect(tokens[12]).toEqual value: ']', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'punctuation.section.array.end.php']
+      expect(tokens[4]).toEqual value: 'array', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+      expect(tokens[5]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
+      expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[7]).toEqual value: 'value', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+      expect(tokens[8]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
+      expect(tokens[9]).toEqual value: '=', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'keyword.operator.assignment.php']
+      expect(tokens[10]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
+      expect(tokens[11]).toEqual value: '[', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'punctuation.section.array.begin.php']
+      expect(tokens[12]).toEqual value: ']', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'punctuation.section.array.end.php']
       expect(tokens[13]).toEqual value: ')', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
       expect(tokens[14]).toEqual value: ' ', scopes: ['source.php']
       expect(tokens[15]).toEqual value: '{', scopes: ['source.php', 'punctuation.definition.begin.bracket.curly.php']
@@ -1001,15 +1001,15 @@ describe 'PHP grammar', ->
     it 'tokenizes a non-empty array', ->
       {tokens} = grammar.tokenizeLine "function not_empty_array_test(array $value = [1,2,'3']) {}"
 
-      expect(tokens[11]).toEqual value: '[', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'punctuation.section.array.begin.php']
-      expect(tokens[12]).toEqual value: '1', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'constant.numeric.decimal.php']
-      expect(tokens[13]).toEqual value: ',', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php']
-      expect(tokens[14]).toEqual value: '2', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'constant.numeric.decimal.php']
-      expect(tokens[15]).toEqual value: ',', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php']
-      expect(tokens[16]).toEqual value: '\'', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'string.quoted.single.php', 'punctuation.definition.string.begin.php']
-      expect(tokens[17]).toEqual value: '3', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'string.quoted.single.php']
-      expect(tokens[18]).toEqual value: '\'', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
-      expect(tokens[19]).toEqual value: ']', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'punctuation.section.array.end.php']
+      expect(tokens[11]).toEqual value: '[', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'punctuation.section.array.begin.php']
+      expect(tokens[12]).toEqual value: '1', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'constant.numeric.decimal.php']
+      expect(tokens[13]).toEqual value: ',', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'punctuation.separator.delimiter.php']
+      expect(tokens[14]).toEqual value: '2', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'constant.numeric.decimal.php']
+      expect(tokens[15]).toEqual value: ',', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'punctuation.separator.delimiter.php']
+      expect(tokens[16]).toEqual value: '\'', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'string.quoted.single.php', 'punctuation.definition.string.begin.php']
+      expect(tokens[17]).toEqual value: '3', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'string.quoted.single.php']
+      expect(tokens[18]).toEqual value: '\'', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
+      expect(tokens[19]).toEqual value: ']', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'punctuation.section.array.end.php']
 
     it 'tokenizes default value with non-lowercase array type hinting', ->
       {tokens} = grammar.tokenizeLine 'function array_test(Array $value = []) {}'
@@ -1018,15 +1018,15 @@ describe 'PHP grammar', ->
       expect(tokens[1]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php']
       expect(tokens[2]).toEqual value: 'array_test', scopes: ['source.php', 'meta.function.php', 'entity.name.function.php']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
-      expect(tokens[4]).toEqual value: 'Array', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'storage.type.php']
-      expect(tokens[5]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php']
-      expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'variable.other.php', 'punctuation.definition.variable.php']
-      expect(tokens[7]).toEqual value: 'value', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'variable.other.php']
-      expect(tokens[8]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php']
-      expect(tokens[9]).toEqual value: '=', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'keyword.operator.assignment.php']
-      expect(tokens[10]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php']
-      expect(tokens[11]).toEqual value: '[', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'punctuation.section.array.begin.php']
-      expect(tokens[12]).toEqual value: ']', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.array.php', 'punctuation.section.array.end.php']
+      expect(tokens[4]).toEqual value: 'Array', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'storage.type.php']
+      expect(tokens[5]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
+      expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[7]).toEqual value: 'value', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+      expect(tokens[8]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
+      expect(tokens[9]).toEqual value: '=', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'keyword.operator.assignment.php']
+      expect(tokens[10]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php']
+      expect(tokens[11]).toEqual value: '[', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'punctuation.section.array.begin.php']
+      expect(tokens[12]).toEqual value: ']', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'punctuation.section.array.end.php']
       expect(tokens[13]).toEqual value: ')', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
       expect(tokens[14]).toEqual value: ' ', scopes: ['source.php']
       expect(tokens[15]).toEqual value: '{', scopes: ['source.php', 'punctuation.definition.begin.bracket.curly.php']
@@ -1069,7 +1069,7 @@ describe 'PHP grammar', ->
       expect(tokens[5]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php']
       expect(tokens[6]).toEqual value: ':', scopes: ['source.php', 'meta.function.php', 'keyword.operator.return-value.php']
       expect(tokens[7]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php']
-      expect(tokens[8]).toEqual value: 'Client', scopes: ['source.php', 'meta.function.php', 'storage.type.php']
+      expect(tokens[8]).toEqual value: 'Client', scopes: ['source.php', 'meta.function.php', 'support.class.php']
       expect(tokens[9]).toEqual value: ' ', scopes: ['source.php']
 
     it 'tokenizes nullable return values', ->
@@ -1078,7 +1078,7 @@ describe 'PHP grammar', ->
       expect(tokens[6]).toEqual value: ':', scopes: ['source.php', 'meta.function.php', 'keyword.operator.return-value.php']
       expect(tokens[7]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php']
       expect(tokens[8]).toEqual value: '?', scopes: ['source.php', 'meta.function.php', 'keyword.operator.nullable-type.php']
-      expect(tokens[9]).toEqual value: 'Client', scopes: ['source.php', 'meta.function.php', 'storage.type.php']
+      expect(tokens[9]).toEqual value: 'Client', scopes: ['source.php', 'meta.function.php', 'support.class.php']
 
       {tokens} = grammar.tokenizeLine 'function test() : ?   Client {}'
 
@@ -1086,7 +1086,7 @@ describe 'PHP grammar', ->
       expect(tokens[7]).toEqual value: ' ', scopes: ['source.php', 'meta.function.php']
       expect(tokens[8]).toEqual value: '?', scopes: ['source.php', 'meta.function.php', 'keyword.operator.nullable-type.php']
       expect(tokens[9]).toEqual value: '   ', scopes: ['source.php', 'meta.function.php']
-      expect(tokens[10]).toEqual value: 'Client', scopes: ['source.php', 'meta.function.php', 'storage.type.php']
+      expect(tokens[10]).toEqual value: 'Client', scopes: ['source.php', 'meta.function.php', 'support.class.php']
 
     it 'tokenizes function names with characters other than letters or numbers', ->
       # Char 160 is hex 0xA0, which is between 0x7F and 0xFF, making it a valid PHP identifier
@@ -1294,7 +1294,8 @@ describe 'PHP grammar', ->
 
       expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
       expect(tokens[4]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
-      expect(tokens[6]).toEqual value: '\\Client', scopes: ["source.php", "meta.function.closure.php", "storage.type.php"]
+      expect(tokens[6]).toEqual value: '\\', scopes: ["source.php", "meta.function.closure.php", "support.other.namespace.php", "punctuation.separator.inheritance.php"]
+      expect(tokens[7]).toEqual value: 'Client', scopes: ["source.php", "meta.function.closure.php", "support.class.php"]
 
     it 'tokenizes nullable return values', ->
       {tokens} = grammar.tokenizeLine 'function() :? Client {}'
@@ -1302,14 +1303,14 @@ describe 'PHP grammar', ->
       expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
       expect(tokens[4]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
       expect(tokens[5]).toEqual value: '?', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.nullable-type.php"]
-      expect(tokens[7]).toEqual value: 'Client', scopes: ["source.php", "meta.function.closure.php", "storage.type.php"]
+      expect(tokens[7]).toEqual value: 'Client', scopes: ["source.php", "meta.function.closure.php", "support.class.php"]
 
       {tokens} = grammar.tokenizeLine 'function():  ?Client {}'
 
       expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
       expect(tokens[3]).toEqual value: ':', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.return-value.php"]
       expect(tokens[5]).toEqual value: '?', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.nullable-type.php"]
-      expect(tokens[6]).toEqual value: 'Client', scopes: ["source.php", "meta.function.closure.php", "storage.type.php"]
+      expect(tokens[6]).toEqual value: 'Client', scopes: ["source.php", "meta.function.closure.php", "support.class.php"]
 
     it 'tokenizes closure returning reference', ->
       {tokens} = grammar.tokenizeLine 'function&() {}'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -592,6 +592,22 @@ describe 'PHP grammar', ->
       expect(tokens[4][0]).toEqual value: '}', scopes: ['source.php', 'meta.use.php', 'punctuation.definition.use.end.bracket.curly.php']
       expect(tokens[4][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
+    it 'tokenizes trailing comma in use statements', ->
+      lines = grammar.tokenizeLines '''
+        use some\\namespace\\{
+          ClassA,
+          ClassB,
+        };
+      '''
+
+      expect(lines[0][0]).toEqual value: 'use', scopes: ['source.php', 'meta.use.php', 'keyword.other.use.php']
+      expect(lines[0][6]).toEqual value: '{', scopes: ['source.php', 'meta.use.php', 'punctuation.definition.use.begin.bracket.curly.php']
+      expect(lines[1][1]).toEqual value: 'ClassA', scopes: ['source.php', 'meta.use.php', 'support.class.php']
+      expect(lines[1][2]).toEqual value: ',', scopes: ['source.php', 'meta.use.php', 'punctuation.separator.delimiter.php']
+      expect(lines[2][1]).toEqual value: 'ClassB', scopes: ['source.php', 'meta.use.php', 'support.class.php']
+      expect(lines[2][2]).toEqual value: ',', scopes: ['source.php', 'meta.use.php', 'punctuation.separator.delimiter.php']
+      expect(lines[3][0]).toEqual value: '}', scopes: ['source.php', 'meta.use.php', 'punctuation.definition.use.end.bracket.curly.php']
+
   describe 'classes', ->
     it 'tokenizes class declarations', ->
       {tokens} = grammar.tokenizeLine 'class Test { /* stuff */ }'
@@ -1058,6 +1074,20 @@ describe 'PHP grammar', ->
       expect(tokens[23]).toEqual value: 'null', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'constant.language.php']
       expect(tokens[24]).toEqual value: ')', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
 
+    it 'tokenizes trailing comma in function parameters', ->
+      {tokens} = grammar.tokenizeLine 'function abc($a, $b,){}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ['source.php', 'meta.function.php', 'storage.type.function.php']
+      expect(tokens[2]).toEqual value: 'abc', scopes: ['source.php', 'meta.function.php', 'entity.name.function.php']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
+      expect(tokens[4]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.no-default.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[5]).toEqual value: 'a', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.no-default.php', 'variable.other.php']
+      expect(tokens[6]).toEqual value: ',', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'punctuation.separator.delimiter.php']
+      expect(tokens[8]).toEqual value: '$', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.no-default.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[9]).toEqual value: 'b', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'meta.function.parameter.no-default.php', 'variable.other.php']
+      expect(tokens[10]).toEqual value: ',', scopes: ['source.php', 'meta.function.php', 'meta.function.parameters.php', 'punctuation.separator.delimiter.php']
+      expect(tokens[11]).toEqual value: ')', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
+
     it 'tokenizes return values', ->
       {tokens} = grammar.tokenizeLine 'function test() : Client {}'
 
@@ -1151,6 +1181,15 @@ describe 'PHP grammar', ->
       expect(tokens[7]).toEqual value: 'b', scopes: ['source.php', 'meta.function-call.php', 'string.quoted.single.php']
       expect(tokens[8]).toEqual value: "'", scopes: ['source.php', 'meta.function-call.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
       expect(tokens[9]).toEqual value: ')', scopes: ['source.php', 'meta.function-call.php', 'punctuation.definition.arguments.end.bracket.round.php']
+
+    it 'tokenizes trailing comma in parameters of function call', ->
+      {tokens} = grammar.tokenizeLine 'add(1,2,)'
+
+      expect(tokens[0]).toEqual value: 'add', scopes: ['source.php', 'meta.function-call.php', 'entity.name.function.php']
+      expect(tokens[2]).toEqual value: '1', scopes: ['source.php', 'meta.function-call.php', 'constant.numeric.decimal.php']
+      expect(tokens[3]).toEqual value: ',', scopes: ['source.php', 'meta.function-call.php', 'punctuation.separator.delimiter.php']
+      expect(tokens[4]).toEqual value: '2', scopes: ['source.php', 'meta.function-call.php', 'constant.numeric.decimal.php']
+      expect(tokens[5]).toEqual value: ',', scopes: ['source.php', 'meta.function-call.php', 'punctuation.separator.delimiter.php']
 
     it 'tokenizes builtin function calls', ->
       {tokens} = grammar.tokenizeLine "echo('Hi!')"
@@ -1358,6 +1397,18 @@ describe 'PHP grammar', ->
       expect(tokens[8]).toEqual value: '&', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php", "storage.modifier.reference.php"]
       expect(tokens[9]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php", "punctuation.definition.variable.php"]
       expect(tokens[10]).toEqual value: 'a', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php"]
+
+    it 'tokenizes trailing comma in closure parameters and use inheritance', ->
+      {tokens} = grammar.tokenizeLine 'function($a,)use($b,){}'
+
+      expect(tokens[0]).toEqual value: 'function', scopes: ['source.php', 'meta.function.closure.php', 'storage.type.function.php']
+      expect(tokens[2]).toEqual value: '$', scopes: ['source.php', 'meta.function.closure.php', 'meta.function.parameters.php', 'meta.function.parameter.no-default.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[3]).toEqual value: 'a', scopes: ['source.php', 'meta.function.closure.php', 'meta.function.parameters.php', 'meta.function.parameter.no-default.php', 'variable.other.php']
+      expect(tokens[4]).toEqual value: ',', scopes: ['source.php', 'meta.function.closure.php', 'meta.function.parameters.php', 'punctuation.separator.delimiter.php']
+      expect(tokens[6]).toEqual value: 'use', scopes: ['source.php', 'meta.function.closure.php', 'meta.function.closure.use.php', 'keyword.other.function.use.php']
+      expect(tokens[8]).toEqual value: '$', scopes: ['source.php', 'meta.function.closure.php', 'meta.function.closure.use.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[9]).toEqual value: 'b', scopes: ['source.php', 'meta.function.closure.php', 'meta.function.closure.use.php', 'variable.other.php']
+      expect(tokens[10]).toEqual value: ',', scopes: ['source.php', 'meta.function.closure.php', 'meta.function.closure.use.php', 'punctuation.separator.delimiter.php']
 
   describe 'arrow functions', ->
     it 'tokenizes arrow functions', ->

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1332,28 +1332,29 @@ describe 'PHP grammar', ->
       {tokens} = grammar.tokenizeLine 'function () use($a) {}'
 
       expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
-      expect(tokens[5]).toEqual value: 'use', scopes: ["source.php", "meta.function.closure.php", "keyword.other.function.use.php"]
-      expect(tokens[6]).toEqual value: '(', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.begin.bracket.round.php"]
+      expect(tokens[5]).toEqual value: 'use', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "keyword.other.function.use.php"]
+      expect(tokens[6]).toEqual value: '(', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "punctuation.definition.parameters.begin.bracket.round.php"]
       expect(tokens[7]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php", "punctuation.definition.variable.php"]
       expect(tokens[8]).toEqual value: 'a', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php"]
-      expect(tokens[9]).toEqual value: ')', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.end.bracket.round.php"]
+      expect(tokens[9]).toEqual value: ')', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "punctuation.definition.parameters.end.bracket.round.php"]
 
       {tokens} = grammar.tokenizeLine 'function () use($a  ,$b) {}'
 
       expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
-      expect(tokens[5]).toEqual value: 'use', scopes: ["source.php", "meta.function.closure.php", "keyword.other.function.use.php"]
-      expect(tokens[6]).toEqual value: '(', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.begin.bracket.round.php"]
+      expect(tokens[5]).toEqual value: 'use', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "keyword.other.function.use.php"]
+      expect(tokens[6]).toEqual value: '(', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "punctuation.definition.parameters.begin.bracket.round.php"]
       expect(tokens[7]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php", "punctuation.definition.variable.php"]
       expect(tokens[8]).toEqual value: 'a', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php"]
+      expect(tokens[10]).toEqual value: ',', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "punctuation.separator.delimiter.php"]
       expect(tokens[11]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php", "punctuation.definition.variable.php"]
       expect(tokens[12]).toEqual value: 'b', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php"]
-      expect(tokens[13]).toEqual value: ')', scopes: ["source.php", "meta.function.closure.php", "punctuation.definition.parameters.end.bracket.round.php"]
+      expect(tokens[13]).toEqual value: ')', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "punctuation.definition.parameters.end.bracket.round.php"]
 
     it 'tokenizes use inheritance by reference', ->
       {tokens} = grammar.tokenizeLine 'function () use( &$a ) {}'
 
       expect(tokens[0]).toEqual value: 'function', scopes: ["source.php", "meta.function.closure.php", "storage.type.function.php"]
-      expect(tokens[5]).toEqual value: 'use', scopes: ["source.php", "meta.function.closure.php", "keyword.other.function.use.php"]
+      expect(tokens[5]).toEqual value: 'use', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "keyword.other.function.use.php"]
       expect(tokens[8]).toEqual value: '&', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php", "storage.modifier.reference.php"]
       expect(tokens[9]).toEqual value: '$', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php", "punctuation.definition.variable.php"]
       expect(tokens[10]).toEqual value: 'a', scopes: ["source.php", "meta.function.closure.php", "meta.function.closure.use.php", "variable.other.php"]


### PR DESCRIPTION
This is bigger update since all of these changes are done on the same parts of code and they are dependent on each other, so it's hard to separate them to individual PRs.

Don't be overwhelmed by long change list (I'm a bit pedantic), many points are the result of one fix/change, but code changes are rather straight forward.

### Description of the Change

#### added
- `mixed` type (PHP 8.0)
- `static` type in method's return (PHP 8.0)
- added union types (PHP 8.0)
- `meta.function.parameter.variadic.php` since this is unique parameter without default value, token could be more useful than removed `array` variant
- constructor property promotion (PHP 8.0)

#### fixed
- variadic parameter handling e.g. no default value allowed
- multiple `$` in a parameters (only one is allowed)
- classes in type hints are now properly tokenized `support.class.php` instead of `storage.type.php`. Fixes #387, microsoft/vscode#95029
- use inheritance in closures: added comma token and `meta.function.closure.use.php` widened to whole `use` statement
- constructor no longer allows return type declaration

#### changed
- type hints are now single separate rule
- for consistency, boundary spaces are not a part of the parameter nor the variable token

#### removed
- `meta.function.parameter.array.php` and `invalid.illegal.non-null-typehinted.php` - problematic with union types (since 8.0), broken by constant expressions in default value (since 5.6) and logic errors should be checked by intellisense anyway. Also fixes #363 and #390 2nd point
- `storage.type.php` for namespace name in namespaced class reference - probably added by mistake in 2 places (one by me, sorry)

#### test spec

- trailing comma (already supported; PHP 8.0)
  - use namespace
  - function parameters
  - closure parameters, use inheritance
- basic method (missing tests)
- union types (with `false`)
- `mixed` type
- `static` return type in methods
- constructor property promotion
- constructor illegal return type declaration

### Alternate Designs

- We may want to add `meta.function.parameter.type.php` and `meta.function.return.type.php` (`type`/`typehint`) for whole type hint (union, nullable). Could be useful, but feedback is needed.
- `parent`, `self`, `static` probably should be changed from `storage.type.php` to `support.class.parent.php` or `keyword.other.parent.php` or something like this.
- Methods are tokenized as `meta.function.php`, maybe this should be changed to `meta.function.method.php` or `meta.method.php`
- `parameter-default-types` can be changed to `$self`, but more tests are needed.

### Possible Drawbacks

This update will break PR #389, but at the same time fixes original problem making mentioned PR not needed anymore.

There may be some coloring changes, but all should be improvements, rather than degradation.

### Applicable Issues

PHP 8.0 update log: #395 

fix #363 fix #387 fix microsoft/vscode#95029
closes #389
partially #390 (point 2)