### PR TITLE
Nullsafe operator

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2163,7 +2163,7 @@
   'object':
     'patterns': [
       {
-        'begin': '(->)(\\$?{)'
+        'begin': '(\\??->)\\s*(\\$?{)'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.class.php'
@@ -2180,7 +2180,7 @@
         ]
       }
       {
-        'begin': '(?i)(->)([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)\\s*(\\()'
+        'begin': '(?i)(\\??->)\\s*([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)\\s*(\\()'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.class.php'
@@ -2210,7 +2210,7 @@
             'name': 'variable.other.property.php'
           '3':
             'name': 'punctuation.definition.variable.php'
-        'match': '(?i)(->)((\\$+)?[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?'
+        'match': '(?i)(\\??->)\\s*((\\$+)?[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?'
       }
     ]
   'php-types':
@@ -2301,11 +2301,11 @@
       }
       {
         'begin': '''(?xi)
-          (?=[a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+(::)
-            ([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?
+          (?=[a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+
+            (::)\\s*([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?
           )
         '''
-        'end': '(?i)(::)([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?'
+        'end': '(?i)(::)\\s*([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?'
         'endCaptures':
           '1':
             'name': 'keyword.operator.class.php'
@@ -3707,9 +3707,9 @@
             'name': 'punctuation.section.array.end.php'
         # Simple syntax: $foo, $foo[0], $foo[$bar], $foo->bar
         'match': '''(?xi)
-          ((\\$)(?<name>[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*))
+          ((\\$)(?<name>[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*))\\s*
           (?:
-            (->)(\\g<name>)
+            (\\??->)\\s*(\\g<name>)
             |
             (\\[)(?:(\\d+)|((\\$)\\g<name>)|([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*))(\\])
           )?

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1481,16 +1481,27 @@ describe 'PHP grammar', ->
     it 'tokenizes method calls with no arguments', ->
       {tokens} = grammar.tokenizeLine 'obj->method()'
 
+      expect(tokens[1]).toEqual value: '->', scopes: ['source.php', 'meta.method-call.php', 'keyword.operator.class.php']
       expect(tokens[2]).toEqual value: 'method', scopes: ['source.php', 'meta.method-call.php', 'entity.name.function.php']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.php', 'meta.method-call.php', 'punctuation.definition.arguments.begin.bracket.round.php']
       expect(tokens[4]).toEqual value: ')', scopes: ['source.php', 'meta.method-call.php', 'punctuation.definition.arguments.end.bracket.round.php']
 
-      {tokens} = grammar.tokenizeLine 'obj->method ()'
+      {tokens} = grammar.tokenizeLine 'obj-> method ()'
 
+      expect(tokens[1]).toEqual value: '->', scopes: ['source.php', 'meta.method-call.php', 'keyword.operator.class.php']
+      expect(tokens[2]).toEqual value: ' ', scopes: ['source.php', 'meta.method-call.php']
+      expect(tokens[3]).toEqual value: 'method', scopes: ['source.php', 'meta.method-call.php', 'entity.name.function.php']
+      expect(tokens[4]).toEqual value: ' ', scopes: ['source.php', 'meta.method-call.php']
+      expect(tokens[5]).toEqual value: '(', scopes: ['source.php', 'meta.method-call.php', 'punctuation.definition.arguments.begin.bracket.round.php']
+      expect(tokens[6]).toEqual value: ')', scopes: ['source.php', 'meta.method-call.php', 'punctuation.definition.arguments.end.bracket.round.php']
+
+    it 'tokenizes method calls with nullsafe operator', ->
+      {tokens} = grammar.tokenizeLine 'obj?->method()'
+
+      expect(tokens[1]).toEqual value: '?->', scopes: ['source.php', 'meta.method-call.php', 'keyword.operator.class.php']
       expect(tokens[2]).toEqual value: 'method', scopes: ['source.php', 'meta.method-call.php', 'entity.name.function.php']
-      expect(tokens[3]).toEqual value: ' ', scopes: ['source.php', 'meta.method-call.php']
-      expect(tokens[4]).toEqual value: '(', scopes: ['source.php', 'meta.method-call.php', 'punctuation.definition.arguments.begin.bracket.round.php']
-      expect(tokens[5]).toEqual value: ')', scopes: ['source.php', 'meta.method-call.php', 'punctuation.definition.arguments.end.bracket.round.php']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.php', 'meta.method-call.php', 'punctuation.definition.arguments.begin.bracket.round.php']
+      expect(tokens[4]).toEqual value: ')', scopes: ['source.php', 'meta.method-call.php', 'punctuation.definition.arguments.end.bracket.round.php']
 
     it 'tokenizes method calls with arguments', ->
       {tokens} = grammar.tokenizeLine "obj->method(5, 'b')"


### PR DESCRIPTION
#### Changes

- Implementation of https://wiki.php.net/rfc/nullsafe_operator
- allowed whitespaces after `->`, `?->` and `::` e.g. `$cart -> clear()` (this was added in 2 places already, but not everywhere for some reason)