### PR TITLE
Attributes

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1032,10 +1032,7 @@
         ]
       }
       {
-        'match': '[a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+'
-        'patterns': {
-          'include': '#attribute-name'
-        }
+        'include': '#attribute-name'
       }
     ]
   'class-builtin':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -9,6 +9,9 @@
 'scopeName': 'source.php'
 'patterns': [
   {
+    'include': '#attribute'
+  }
+  {
     'include': '#comments'
   }
   {
@@ -204,7 +207,7 @@
     'begin':  '''(?ix)
         (?:
           (?:^|(?<=}))\\s*(?:(abstract|final)\\s+)?(class)\\s+([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)
-          |\\b(new)\\s+(class)\\b # anonymous class
+          |\\b(new)\\b\\s*(\\#\\[.*\\])?\\s*\\b(class)\\b # anonymous class
         )
       '''
     'beginCaptures':
@@ -217,6 +220,12 @@
       '4':
         'name': 'keyword.other.new.php'
       '5':
+        'patterns': [
+          {
+            'include': '#attribute'
+          }
+        ]
+      '6':
         'name': 'storage.type.class.php'
     'end': '}|(?=\\?>)'
     'endCaptures':
@@ -946,6 +955,89 @@
   }
 ]
 'repository':
+  'attribute-name':
+    'patterns': [
+      {
+        'begin': '(?i)(?=\\\\?[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*\\\\)'
+        'end': '''(?xi)
+          ( [a-z_\\x{7f}-\\x{7fffffff}] [a-z0-9_\\x{7f}-\\x{7fffffff}]* )?
+          (?![a-z0-9_\\x{7f}-\\x{7fffffff}\\\\])
+        '''
+        'endCaptures':
+          '1':
+            'name': 'support.attribute.php'
+        'patterns': [
+          {
+            'include': '#namespace'
+          }
+        ]
+      }
+      {
+        # There will be other attributes in the future
+        'match': '''(?xi)
+          (\\\\)?\\b(Attribute)\\b
+        '''
+        'name': 'support.attribute.builtin.php'
+        'captures':
+          '1':
+            'name': 'punctuation.separator.inheritance.php'
+      }
+      {
+        'begin': '(?i)(?=[\\\\a-z_\\x{7f}-\\x{7fffffff}])'
+        'end': '''(?xi)
+          ( [a-z_\\x{7f}-\\x{7fffffff}] [a-z0-9_\\x{7f}-\\x{7fffffff}]* )?
+          (?![a-z0-9_\\x{7f}-\\x{7fffffff}\\\\])
+        '''
+        'endCaptures':
+          '1':
+            'name': 'support.attribute.php'
+        'patterns': [
+          {
+            'include': '#namespace'
+          }
+        ]
+      }
+    ]
+  'attribute':
+    'begin': '\\#\\['
+    'end': '\\]'
+    'name': 'meta.attribute.php'
+    'patterns': [
+      {
+        'match': ','
+        'name': 'punctuation.separator.delimiter.php'
+      }
+      {
+        'begin': '([a-zA-Z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)\\s*(\\()'
+        'beginCaptures':
+          '1':
+            'patterns': [
+              {
+                'include': '#attribute-name'
+              }
+            ]
+          '2':
+            'name': 'punctuation.definition.arguments.begin.bracket.round.php'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.arguments.end.bracket.round.php'
+        'patterns': [
+          {
+            'include': '#named-arguments'
+          }
+          {
+            'include': '$self'
+          }
+        ]
+      }
+      {
+        'match': '[a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+'
+        'patterns': {
+          'include': '#attribute-name'
+        }
+      }
+    ]
   'class-builtin':
     'patterns': [
       {

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -206,7 +206,7 @@
   {
     'begin':  '''(?ix)
         (?:
-          (?:^|(?<=}))\\s*(?:(abstract|final)\\s+)?(class)\\s+([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)
+          \\b(?:(abstract|final)\\s+)?(class)\\s+([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)
           |\\b(new)\\b\\s*(\\#\\[.*\\])?\\s*\\b(class)\\b # anonymous class
         )
       '''

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1043,7 +1043,7 @@
       {
         'match': '''(?xi)
           (\\\\)?\\b
-          ((APC|Append)Iterator|Array(Access|Iterator|Object)
+          (Attribute|(APC|Append)Iterator|Array(Access|Iterator|Object)
           |Bad(Function|Method)CallException
           |(Caching|CallbackFilter)Iterator|Collator|Collectable|Cond|Countable|CURLFile
           |Date(Interval|Period|Time(Interface|Immutable|Zone)?)?|Directory(Iterator)?|DomainException

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -2080,6 +2080,145 @@ describe 'PHP grammar', ->
     expect(tokens[3]).toEqual value: ' ', scopes: ['source.php']
     expect(tokens[4]).toEqual value: ')', scopes: ['source.php', 'punctuation.definition.storage-type.end.bracket.round.php']
 
+  describe 'attributes', ->
+    it 'should tokenize basic attribute', ->
+      lines = grammar.tokenizeLines '''
+        #[ExampleAttribute]
+        class Foo {}
+      '''
+
+      expect(lines[0][0]).toEqual value: '#[', scopes: ['source.php', 'meta.attribute.php']
+      expect(lines[0][1]).toEqual value: 'ExampleAttribute', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.php']
+      expect(lines[0][2]).toEqual value: ']', scopes: ['source.php', 'meta.attribute.php']
+      expect(lines[1][0]).toEqual value: 'class', scopes: ['source.php', 'meta.class.php', 'storage.type.class.php']
+      expect(lines[1][2]).toEqual value: 'Foo', scopes: ['source.php', 'meta.class.php', 'entity.name.type.class.php']
+
+    it 'should tokenize inline attribute', ->
+      {tokens} = grammar.tokenizeLine '#[ExampleAttribute] class Foo {}'
+
+      expect(tokens[0]).toEqual value: '#[', scopes: ['source.php', 'meta.attribute.php']
+      expect(tokens[1]).toEqual value: 'ExampleAttribute', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.php']
+      expect(tokens[2]).toEqual value: ']', scopes: ['source.php', 'meta.attribute.php']
+      expect(tokens[4]).toEqual value: 'class', scopes: ['source.php', 'meta.class.php', 'storage.type.class.php']
+      expect(tokens[6]).toEqual value: 'Foo', scopes: ['source.php', 'meta.class.php', 'entity.name.type.class.php']
+
+    it 'should tokenize attribute with namespace', ->
+      {tokens} = grammar.tokenizeLine '#[Foo\\Bar\\Attribute]'
+
+      expect(tokens[0]).toEqual value: '#[', scopes: ['source.php', 'meta.attribute.php']
+      expect(tokens[1]).toEqual value: 'Foo', scopes: ['source.php', 'meta.attribute.php', 'support.other.namespace.php']
+      expect(tokens[2]).toEqual value: '\\', scopes: ['source.php', 'meta.attribute.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[3]).toEqual value: 'Bar', scopes: ['source.php', 'meta.attribute.php', 'support.other.namespace.php']
+      expect(tokens[4]).toEqual value: '\\', scopes: ['source.php', 'meta.attribute.php', 'support.other.namespace.php', 'punctuation.separator.inheritance.php']
+      expect(tokens[5]).toEqual value: 'Attribute', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.php']
+      expect(tokens[6]).toEqual value: ']', scopes: ['source.php', 'meta.attribute.php']
+
+    it 'should tokenize multiple attributes', ->
+      {tokens} = grammar.tokenizeLine '#[Attribute1, Attribute2]'
+
+      expect(tokens[0]).toEqual value: '#[', scopes: ['source.php', 'meta.attribute.php']
+      expect(tokens[1]).toEqual value: 'Attribute1', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.php']
+      expect(tokens[2]).toEqual value: ',', scopes: ['source.php', 'meta.attribute.php', 'punctuation.separator.delimiter.php']
+      expect(tokens[4]).toEqual value: 'Attribute2', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.php']
+      expect(tokens[5]).toEqual value: ']', scopes: ['source.php', 'meta.attribute.php']
+
+    it 'should tokenize attribute with arguments', ->
+      {tokens} = grammar.tokenizeLine '#[Attribute1, Attribute2(true, 2, [3.1, 3.2])]'
+
+      expect(tokens[0]).toEqual value: '#[', scopes: ['source.php', 'meta.attribute.php']
+      expect(tokens[1]).toEqual value: 'Attribute1', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.php']
+      expect(tokens[2]).toEqual value: ',', scopes: ['source.php', 'meta.attribute.php', 'punctuation.separator.delimiter.php']
+      expect(tokens[4]).toEqual value: 'Attribute2', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.php']
+      expect(tokens[5]).toEqual value: '(', scopes: ['source.php', 'meta.attribute.php', 'punctuation.definition.arguments.begin.bracket.round.php']
+      expect(tokens[6]).toEqual value: 'true', scopes: ['source.php', 'meta.attribute.php', 'constant.language.php']
+      expect(tokens[7]).toEqual value: ',', scopes: ['source.php', 'meta.attribute.php', 'punctuation.separator.delimiter.php']
+      expect(tokens[9]).toEqual value: '2', scopes: ['source.php', 'meta.attribute.php', 'constant.numeric.decimal.php']
+      expect(tokens[10]).toEqual value: ',', scopes: ['source.php', 'meta.attribute.php', 'punctuation.separator.delimiter.php']
+      expect(tokens[12]).toEqual value: '[', scopes: ['source.php', 'meta.attribute.php', 'punctuation.section.array.begin.php']
+      expect(tokens[13]).toEqual value: '3', scopes: ['source.php', 'meta.attribute.php', 'constant.numeric.decimal.php']
+      expect(tokens[14]).toEqual value: '.', scopes: ['source.php', 'meta.attribute.php', 'constant.numeric.decimal.php', 'punctuation.separator.decimal.period.php']
+      expect(tokens[15]).toEqual value: '1', scopes: ['source.php', 'meta.attribute.php', 'constant.numeric.decimal.php']
+      expect(tokens[16]).toEqual value: ',', scopes: ['source.php', 'meta.attribute.php', 'punctuation.separator.delimiter.php']
+      expect(tokens[18]).toEqual value: '3', scopes: ['source.php', 'meta.attribute.php', 'constant.numeric.decimal.php']
+      expect(tokens[19]).toEqual value: '.', scopes: ['source.php', 'meta.attribute.php', 'constant.numeric.decimal.php', 'punctuation.separator.decimal.period.php']
+      expect(tokens[20]).toEqual value: '2', scopes: ['source.php', 'meta.attribute.php', 'constant.numeric.decimal.php']
+      expect(tokens[21]).toEqual value: ']', scopes: ['source.php', 'meta.attribute.php', 'punctuation.section.array.end.php']
+      expect(tokens[22]).toEqual value: ')', scopes: ['source.php', 'meta.attribute.php', 'punctuation.definition.arguments.end.bracket.round.php']
+      expect(tokens[23]).toEqual value: ']', scopes: ['source.php', 'meta.attribute.php']
+
+    it 'should tokenize multiline attribute', ->
+      lines = grammar.tokenizeLines '''
+        #[ExampleAttribute(
+          'Foo',
+          'Bar',
+        )]
+      '''
+
+      expect(lines[0][0]).toEqual value: '#[', scopes: ['source.php', 'meta.attribute.php']
+      expect(lines[0][1]).toEqual value: 'ExampleAttribute', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.php']
+      expect(lines[0][2]).toEqual value: '(', scopes: ['source.php', 'meta.attribute.php', 'punctuation.definition.arguments.begin.bracket.round.php']
+      expect(lines[1][1]).toEqual value: '\'', scopes: ['source.php', 'meta.attribute.php', 'string.quoted.single.php', 'punctuation.definition.string.begin.php']
+      expect(lines[1][2]).toEqual value: 'Foo', scopes: ['source.php', 'meta.attribute.php', 'string.quoted.single.php']
+      expect(lines[1][3]).toEqual value: '\'', scopes: ['source.php', 'meta.attribute.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
+      expect(lines[1][4]).toEqual value: ',', scopes: ['source.php', 'meta.attribute.php', 'punctuation.separator.delimiter.php']
+      expect(lines[2][1]).toEqual value: '\'', scopes: ['source.php', 'meta.attribute.php', 'string.quoted.single.php', 'punctuation.definition.string.begin.php']
+      expect(lines[2][2]).toEqual value: 'Bar', scopes: ['source.php', 'meta.attribute.php', 'string.quoted.single.php']
+      expect(lines[2][3]).toEqual value: '\'', scopes: ['source.php', 'meta.attribute.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
+      expect(lines[2][4]).toEqual value: ',', scopes: ['source.php', 'meta.attribute.php', 'punctuation.separator.delimiter.php']
+      expect(lines[3][0]).toEqual value: ')', scopes: ['source.php', 'meta.attribute.php', 'punctuation.definition.arguments.end.bracket.round.php']
+      expect(lines[3][1]).toEqual value: ']', scopes: ['source.php', 'meta.attribute.php']
+
+    it 'should tokenize attribute in anonymous class', ->
+      {tokens} = grammar.tokenizeLine '$foo = new #[ExampleAttribute] class {};'
+
+      expect(tokens[0]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[1]).toEqual value: 'foo', scopes: ['source.php', 'variable.other.php']
+      expect(tokens[3]).toEqual value: '=', scopes: ['source.php', 'keyword.operator.assignment.php']
+      expect(tokens[5]).toEqual value: 'new', scopes: ['source.php', 'meta.class.php', 'keyword.other.new.php']
+      expect(tokens[7]).toEqual value: '#[', scopes: ['source.php', 'meta.class.php', 'meta.attribute.php']
+      expect(tokens[8]).toEqual value: 'ExampleAttribute', scopes: ['source.php', 'meta.class.php', 'meta.attribute.php', 'support.attribute.php']
+      expect(tokens[9]).toEqual value: ']', scopes: ['source.php', 'meta.class.php', 'meta.attribute.php']
+      expect(tokens[11]).toEqual value: 'class', scopes: ['source.php', 'meta.class.php', 'storage.type.class.php']
+      expect(tokens[13]).toEqual value: '{', scopes: ['source.php', 'meta.class.php', 'punctuation.definition.class.begin.bracket.curly.php']
+      expect(tokens[14]).toEqual value: '}', scopes: ['source.php', 'meta.class.php', 'punctuation.definition.class.end.bracket.curly.php']
+      expect(tokens[15]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+
+    it 'should tokenize attribute in arrow function', ->
+      {tokens} = grammar.tokenizeLine '$foo = #[ExampleAttribute] fn($x) => $x;'
+
+      expect(tokens[0]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[1]).toEqual value: 'foo', scopes: ['source.php', 'variable.other.php']
+      expect(tokens[3]).toEqual value: '=', scopes: ['source.php', 'keyword.operator.assignment.php']
+      expect(tokens[5]).toEqual value: '#[', scopes: ['source.php', 'meta.attribute.php']
+      expect(tokens[6]).toEqual value: 'ExampleAttribute', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.php']
+      expect(tokens[7]).toEqual value: ']', scopes: ['source.php', 'meta.attribute.php']
+      expect(tokens[9]).toEqual value: 'fn', scopes: ['source.php', 'meta.function.closure.php', 'storage.type.function.php']
+      expect(tokens[10]).toEqual value: '(', scopes: ['source.php', 'meta.function.closure.php', 'punctuation.definition.parameters.begin.bracket.round.php']
+      expect(tokens[11]).toEqual value: '$', scopes: ['source.php', 'meta.function.closure.php', 'meta.function.parameters.php', 'meta.function.parameter.no-default.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[12]).toEqual value: 'x', scopes: ['source.php', 'meta.function.closure.php', 'meta.function.parameters.php', 'meta.function.parameter.no-default.php', 'variable.other.php']
+      expect(tokens[13]).toEqual value: ')', scopes: ['source.php', 'meta.function.closure.php', 'punctuation.definition.parameters.end.bracket.round.php']
+      expect(tokens[15]).toEqual value: '=>', scopes: ['source.php', 'meta.function.closure.php', 'punctuation.definition.arrow.php']
+      expect(tokens[17]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[18]).toEqual value: 'x', scopes: ['source.php', 'variable.other.php']
+      expect(tokens[19]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+
+    it 'should tokenize builtin attribute', ->
+      lines = grammar.tokenizeLines '''
+        #[Attribute(Attribute::TARGET_CLASS)]
+        class FooAttribute {}
+      '''
+
+      expect(lines[0][0]).toEqual value: '#[', scopes: ['source.php', 'meta.attribute.php']
+      expect(lines[0][1]).toEqual value: 'Attribute', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.builtin.php']
+      expect(lines[0][2]).toEqual value: '(', scopes: ['source.php', 'meta.attribute.php', 'punctuation.definition.arguments.begin.bracket.round.php']
+      expect(lines[0][3]).toEqual value: 'Attribute', scopes: ['source.php', 'meta.attribute.php', 'support.class.builtin.php']
+      expect(lines[0][4]).toEqual value: '::', scopes: ['source.php', 'meta.attribute.php', 'keyword.operator.class.php']
+      expect(lines[0][5]).toEqual value: 'TARGET_CLASS', scopes: ['source.php', 'meta.attribute.php', 'constant.other.class.php']
+      expect(lines[0][6]).toEqual value: ')', scopes: ['source.php', 'meta.attribute.php', 'punctuation.definition.arguments.end.bracket.round.php']
+      expect(lines[0][7]).toEqual value: ']', scopes: ['source.php', 'meta.attribute.php']
+      expect(lines[1][0]).toEqual value: 'class', scopes: ['source.php', 'meta.class.php', 'storage.type.class.php']
+      expect(lines[1][2]).toEqual value: 'FooAttribute', scopes: ['source.php', 'meta.class.php', 'entity.name.type.class.php']
+
   describe 'PHPDoc', ->
     it 'should tokenize @api tag correctly', ->
       lines = grammar.tokenizeLines '''


### PR DESCRIPTION
This is implementation of Attributes added in PHP 8.0. However documentation for this feature is rather bad, so I'd advice you to use sth like https://3v4l.org/ to determinate how this feature really works.

### Implemented:
- argument-less attribute `#[MyAttribute]`
- attribute with arguments `#[MyAttribute(true)]`
- attribute with named arguments `#[MyAttribute(name:'Bob')]`
- namespaced attributes `#[\Ye\Old\Attribute]`
- multiple attributes `#[A,B,C]`
- multilined attributes 
```
#[
A,
B(true)
]
```
- anonymous class attributes (single-line only) `new #[MyAttribute] class {}`, also it's valid to write `new#[MyAttribute]class{}`
- `Attribute` as class name, for use as argument `#[Attribute(Attribute::TARGET_CLASS)]`
- test spec

### Scopes
- `meta.attribute.php` for whole `#[....]`
- `support.attribute.php` for attribute name, w/ namespace scopes like in classes
- `support.attribute.builtin.php` for `Attribute` and future builtins
- arguments are the same as in function call

### Not implemented
- multilined attributes for anonymous classes - I'm not sure if I should implement this, since it would need some trickery to add with TM grammar (feedback is welcome)