### PR TITLE
Adding '$' character for highlight-selected

### DIFF
--- a/settings/language-php.cson
+++ b/settings/language-php.cson
@@ -3344,4 +3344,4 @@
     'decreaseIndentPattern': '^(.*\\*/)?\\s*(}|(\\)+([;,]|\\s*{))|(\\]\\)*([;,]|$))|else:|((end(if|for(each)?|while|switch));))'
 '.text.html.php':
   'editor':
-    'nonWordCharacters': '/\\()"\':,.;<>~!@#%^&*|+=[]{}`?-'
+    'nonWordCharacters': '$/\\()"\':,.;<>~!@#%^&*|+=[]{}`?-'


### PR DESCRIPTION
### Requirements

I have tested this by making a git clone into '/usr/lib/atom/node_modules' and it behaved as intended, with no bugs or warnings.

### Description of the Change

Changes the default value of of "Non Word Characters" in language-php to match the solution in the thread here:

https://discuss.atom.io/t/double-click-highlights-whole-of-variable-in-php/18625

The thread above suggests (from 2015):

```
$/()"’:,.;<>~!@#%^&*|+=[]{}`?-
```

However, adding a `$` character to the current settings would result in the requested change here, being:

```
$/\()"':,.;<>~!@#%^&*|+=[]{}`?-
```

...This is the new value used in this pull request (2021).

### Alternate Designs

NA: There were no alternatives found because this worked on the first try. Since it was also least invasive, trials went no further.

### Benefits

Double-clicking on a PHP variable is not picked up by `highlight-selected` or its `minimap-highlight-selected` variant. This resolves that issue so double-clicking on a PHP variable not only highlights the name of the single variable, but `highlight-selected` picks up other occurrences.

### Possible Drawbacks

The main drawback would be ***if*** the problem lies within the `highlight-selected` package on a deeper coding level.

However, philosophically, this should probably be the default value anyway, as per the Atom discussion. If there is a deeper problem with the `highlight-selected` package, then this bug here helped identify that problem, but this default value should probably be changed anyway.

I'm not an expert in the full code; just doing the leg work rather than adding to other people's to-do lists. I suppose a better way might exist. If so, by all means. But, the problem wasn't solved and this solves it by the official Atom discussion. Cheers!

### Applicable Issues

This does relate to the `higlight-selected` package.

For discussion: Without this fix, the same text still highlighted on double-click. It was `highlight-selected` that failed to pick it up. So, it seems this setting only affected another package (`highlight-selected`), not the native select capability itself. That suggests that other packages may depend on this setting more than native Atom packages do. Not knowing the full code, I don't know, but it seems strange. Still, this fixed the problem by the official discussion I read.
