### PR TITLE
Fix multiple modifiers with non-typed property

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -697,7 +697,7 @@
   }
   {
     'match': '''(?xi)
-      ((?:(?:public|private|protected|static)(?:\\s+|(?=\\?)))+)                     # At least one modifier
+      ((?:(?:public|private|protected|static)(?:\\s+|(?=\\?)))++)                     # At least one modifier
       (
         (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
         [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -731,6 +731,18 @@ describe 'PHP grammar', ->
         expect(lines[1][2]).toEqual value: '?', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "keyword.operator.nullable-type.php"]
         expect(lines[1][4]).toEqual value: 'string', scopes: ["source.php", "meta.class.php", "meta.class.body.php", "storage.type.php"]
 
+      it 'tokenizes 2 modifiers correctly', ->
+        lines = grammar.tokenizeLines '''
+          class Foo {
+            public static $bar = 'baz';
+          }
+        '''
+
+        expect(lines[1][1]).toEqual value: 'public', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'storage.modifier.php']
+        expect(lines[1][3]).toEqual value: 'static', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'storage.modifier.php']
+        expect(lines[1][5]).toEqual value: '$', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(lines[1][6]).toEqual value: 'bar', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'variable.other.php']
+
       it 'tokenizes namespaces', ->
         lines = grammar.tokenizeLines '''
           class A {


### PR DESCRIPTION
`static` was treated as type in properties.

![image](https://user-images.githubusercontent.com/44417092/109766955-2a322500-7bf7-11eb-8836-b52236374a3a.png)

PR includes fix + test spec.