### PR TITLE
Fix: require(), require_once(), include(), include_once() wrong prop

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -351,7 +351,7 @@
         'name': 'keyword.control.${1:/downcase}.php'
   }
   {
-    'begin': '(?i)\\b((?:require|include)(?:_once)?)[\\s\\(]+'
+    'begin': '(?i)\\b((?:require|include)(?:_once)?)(?=\\s|\\()'
     'beginCaptures':
       '1':
         'name': 'keyword.control.import.include.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -351,7 +351,7 @@
         'name': 'keyword.control.${1:/downcase}.php'
   }
   {
-    'begin': '(?i)\\b((?:require|include)(?:_once)?)(?=\\s|\\()'
+    'begin': '(?i)\\b((?:require|include)(?:_once)?)(?=[\\s\\(])'
     'beginCaptures':
       '1':
         'name': 'keyword.control.import.include.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -351,7 +351,7 @@
         'name': 'keyword.control.${1:/downcase}.php'
   }
   {
-    'begin': '(?i)\\b((?:require|include)(?:_once)?)\\s+'
+    'begin': '(?i)\\b((?:require|include)(?:_once)?)[\\s\\(]+'
     'beginCaptures':
       '1':
         'name': 'keyword.control.import.include.php'

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -64,13 +64,15 @@ describe 'PHP in HTML', ->
 
     it 'tokenizes `include` on the same line as <?php', ->
       # https://github.com/atom/language-php/issues/154
-      {tokens} = grammar.tokenizeLine "<?php include 'test'?>"
+      {tokens} = grammar.tokenizeLine "<?php include('test')?>"
 
       expect(tokens[2]).toEqual value: 'include', scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.include.php', 'keyword.control.import.include.php']
+      expect(tokens[3]).toEqual value: "(", scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.include.php', 'punctuation.definition.begin.bracket.round.php']
       expect(tokens[4]).toEqual value: "'", scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.include.php', 'string.quoted.single.php', 'punctuation.definition.string.begin.php']
       expect(tokens[6]).toEqual value: "'", scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.include.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
-      expect(tokens[7]).toEqual value: '?', scopes: ['text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.end.php', 'source.php']
-      expect(tokens[8]).toEqual value: '>', scopes: ['text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.end.php']
+      expect(tokens[7]).toEqual value: ")", scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php', 'meta.include.php', 'punctuation.definition.end.bracket.round.php']
+      expect(tokens[8]).toEqual value: '?', scopes: ['text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.end.php', 'source.php']
+      expect(tokens[9]).toEqual value: '>', scopes: ['text.html.php', 'meta.embedded.line.php', 'punctuation.section.embedded.end.php']
 
     it 'tokenizes namespaces immediately following <?php', ->
       {tokens} = grammar.tokenizeLine '<?php namespace Test;'


### PR DESCRIPTION
From: microsoft/vscode#120071
## Description of the Change
The require/include commands have two ways to use:
Without parentheses:
```php
<?php
require 'file.ext';
require_once 'file.ext';
```

And with parentheses, like this:
```php
require('file.ext');
require_once('file.ext');
```

However, the syntax highlight were only detecting the right scope of the command that doesn't use parentheses:

<table><tr><td>
<img src="https://user-images.githubusercontent.com/49572917/112789566-bd624d00-9033-11eb-8744-d6cdc5ed3eb6.png">
</td><td>
<img src="https://user-images.githubusercontent.com/49572917/112789584-c521f180-9033-11eb-94cc-60d91d9d55ab.png">
</td></tr></table>

## Fix
This pull request resolves it by adding the **`(`** char after the **`require`**/**`require_once`** and **`include`**/**`include_once`** as a valid match to the  **`keyword.control.import.include.php`** scope.
