### PR TITLE
Update php.cson to detect SQL CTEs

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2697,7 +2697,7 @@
     'match': '\\\\(?:\\\\(?:\\\\[\\\\\']?|[^\'])|.)'
     'name': 'constant.character.escape.php'
   'sql-string-double-quoted':
-    'begin': '"\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND)\\b)'
+    'begin': '"\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'
@@ -2766,7 +2766,7 @@
       }
     ]
   'sql-string-single-quoted':
-    'begin': '\'\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND)\\b)'
+    'begin': '\'\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'


### PR DESCRIPTION
### Description of the Change

Update `php.cson` to detect SQL CTEs by making it detect `"WITH ... "` (both single and double quoted) as an SQL string.

SQL "common table expressions" (CTE) begin with the `WITH` keyword. More info:
https://docs.microsoft.com/en-us/sql/t-sql/queries/with-common-table-expression-transact-sql?view=sql-server-ver15#examples

### Benefits

CTEs are syntax highlighted. Currently they are not, but they are still valid SQL.

### Possible Drawbacks

None
