### PR TITLE
Support blade syntax in heredoc

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -48,6 +48,15 @@
         'include': '#php-tag'
       }
     ]
+  'L:meta.embedded.php.blade':
+    'patterns': [
+      {
+        "include": "text.html.basic"
+      }
+      {
+        'include': 'text.html.php.blade#blade'
+      }
+    ]
 'patterns': [
   {
     'begin': '\\A#!'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1888,6 +1888,31 @@
         ]
       }
       {
+        'begin': '(<<<)\\s*("?)(BLADE)(\\2)(\\s*)$'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.begin.php'
+          '1':
+            'name': 'punctuation.definition.string.php'
+          '3':
+            'name': 'keyword.operator.heredoc.php'
+          '5':
+            'name': 'invalid.illegal.trailing-whitespace.php'
+        'contentName': 'text.html.php.blade'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.php'
+          '1':
+            'name': 'keyword.operator.heredoc.php'
+        'name': 'meta.embedded.php.blade'
+        'patterns': [
+          {
+            'include': '#interpolation'
+          }
+        ]
+      }
+      {
         'begin': '(?i)(<<<)\\s*("?)([a-z_\\x{7f}-\\x{10ffff}]+[a-z0-9_\\x{7f}-\\x{10ffff}]*)(\\2)(\\s*)'
         'beginCaptures':
           '1':
@@ -2124,6 +2149,26 @@
             'name': 'comment.line.number-sign.php'
           }
         ]
+      }
+      {
+        'begin': '(<<<)\\s*\'(BLADE)\'(\\s*)$'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.begin.php'
+          '1':
+            'name': 'punctuation.definition.string.php'
+          '2':
+            'name': 'keyword.operator.nowdoc.php'
+          '3':
+            'name': 'invalid.illegal.trailing-whitespace.php'
+        'contentName': 'text.html.php.blade'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.php'
+          '1':
+            'name': 'keyword.operator.nowdoc.php'
+        'name': 'meta.embedded.php.blade'
       }
       {
         'begin': '(?i)(<<<)\\s*\'([a-z_\\x{7f}-\\x{10ffff}]+[a-z0-9_\\x{7f}-\\x{10ffff}]*)\'(\\s*)'


### PR DESCRIPTION
This PR is adding support for heredoc blade syntax via `<<<BLADE` or `<<<'BLADE'`. Since this is dependent on 3-rd party plugin, there is no tests included.

Works with plugins (both are using similar or identical syntax):
https://atom.io/packages/language-blade
https://marketplace.visualstudio.com/items?itemName=onecentlin.laravel-blade

Request: https://github.com/bmewburn/vscode-intelephense/issues/1757
CC: @bastinald