### PR TITLE
Explicit octal notation

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2232,6 +2232,10 @@
         'name': 'constant.numeric.binary.php'
       }
       {
+        'match': '0[oO][0-7]+(?:_[0-7]+)*'
+        'name': 'constant.numeric.octal.php'
+      }
+      {
         'match': '0(?:_?[0-7]+)+'
         'name': 'constant.numeric.octal.php'
       }

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1957,6 +1957,12 @@ describe 'PHP grammar', ->
       {tokens} = grammar.tokenizeLine '0010'
       expect(tokens[0]).toEqual value: '0010', scopes: ['source.php', 'constant.numeric.octal.php']
 
+      {tokens} = grammar.tokenizeLine '0o010'
+      expect(tokens[0]).toEqual value: '0o010', scopes: ['source.php', 'constant.numeric.octal.php']
+
+      {tokens} = grammar.tokenizeLine '0O10'
+      expect(tokens[0]).toEqual value: '0O10', scopes: ['source.php', 'constant.numeric.octal.php']
+
     it 'tokenizes decimals', ->
       {tokens} = grammar.tokenizeLine '1234'
       expect(tokens[0]).toEqual value: '1234', scopes: ['source.php', 'constant.numeric.decimal.php']
@@ -2010,6 +2016,12 @@ describe 'PHP grammar', ->
 
       {tokens} = grammar.tokenizeLine '0_655'
       expect(tokens[0]).toEqual value: '0_655', scopes: ['source.php', 'constant.numeric.octal.php']
+
+      {tokens} = grammar.tokenizeLine '0o6_4_4'
+      expect(tokens[0]).toEqual value: '0o6_4_4', scopes: ['source.php', 'constant.numeric.octal.php']
+
+      {tokens} = grammar.tokenizeLine '0O6_4_4'
+      expect(tokens[0]).toEqual value: '0O6_4_4', scopes: ['source.php', 'constant.numeric.octal.php']
 
     it 'tokenizes decimals', ->
       {tokens} = grammar.tokenizeLine '1_234'


### PR DESCRIPTION
PHP 8.1 https://wiki.php.net/rfc/explicit_octal_notation