### PR TITLE
Replace noreturn with never

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -690,8 +690,8 @@
             'name': 'storage.type.php'
           }
           {
-            'match': '\\b(noreturn)\\b',
-            'name': 'keyword.other.type.noreturn.php'
+            'match': '\\b(never)\\b',
+            'name': 'keyword.other.type.never.php'
           }
           {
             'include': '#php-types'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -1721,12 +1721,12 @@ describe 'PHP grammar', ->
       expect(tokens[5]).toEqual value: '?', scopes: ["source.php", "meta.function.closure.php", "keyword.operator.nullable-type.php"]
       expect(tokens[6]).toEqual value: 'Client', scopes: ["source.php", "meta.function.closure.php", "support.class.php"]
 
-    it 'tokenizes noreturn type', ->
-      {tokens} = grammar.tokenizeLine 'function app_exit() : noreturn {}'
+    it 'tokenizes never type', ->
+      {tokens} = grammar.tokenizeLine 'function app_exit() : never {}'
 
       expect(tokens[0]).toEqual value: 'function', scopes: ['source.php', 'meta.function.php', 'storage.type.function.php']
       expect(tokens[6]).toEqual value: ':', scopes: ['source.php', 'meta.function.php', 'keyword.operator.return-value.php']
-      expect(tokens[8]).toEqual value: 'noreturn', scopes: ['source.php', 'meta.function.php', 'keyword.other.type.noreturn.php']
+      expect(tokens[8]).toEqual value: 'never', scopes: ['source.php', 'meta.function.php', 'keyword.other.type.never.php']
 
     it 'tokenizes closure returning reference', ->
       {tokens} = grammar.tokenizeLine 'function&() {}'


### PR DESCRIPTION
I haven't noticed that they changed actual name from `noreturn` to `never`.

https://php.watch/versions/8.1/never-return-type