### PR TITLE
limit allowed characters to UTF-8 range (0x10FFFF)

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -4,7 +4,7 @@
 # due to a quirk with how PHP parses identifiers it looks at each _byte_ rather than _characters_.
 # Therefore while سن is technically not in that range, its hex representation is `d8 b3 d9 86`,
 # and PHP recognizes it as a valid identifier. To handle this behavior in Atom, we use the modified regex
-# [a-z_\x{7f}-\x{7fffffff}][a-z0-9_\x{7f}-\x{7fffffff}]*.
+# [a-z_\x{7f}-\x{10ffff}][a-z0-9_\x{7f}-\x{10ffff}]*.
 # See https://github.com/atom/language-php/issues/301.
 'scopeName': 'source.php'
 'patterns': [
@@ -15,7 +15,7 @@
     'include': '#comments'
   }
   {
-    'begin': '(?i)^\\s*(interface)\\s+([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)\\s*(extends)?\\s*'
+    'begin': '(?i)^\\s*(interface)\\s+([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)\\s*(extends)?\\s*'
     'beginCaptures':
       '1':
         'name': 'storage.type.interface.php'
@@ -23,12 +23,12 @@
         'name': 'entity.name.type.interface.php'
       '3':
         'name': 'storage.modifier.extends.php'
-    'end': '(?i)((?:[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*\\s*,\\s*)*)([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?\\s*(?:(?={)|$)'
+    'end': '(?i)((?:[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*\\s*,\\s*)*)([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)?\\s*(?:(?={)|$)'
     'endCaptures':
       '1':
         'patterns': [
           {
-            'match': '(?i)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*'
+            'match': '(?i)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*'
             'name': 'entity.other.inherited-class.php'
           }
           {
@@ -46,7 +46,7 @@
     ]
   }
   {
-    'begin': '(?i)^\\s*(trait)\\s+([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)'
+    'begin': '(?i)^\\s*(trait)\\s+([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)'
     'beginCaptures':
       '1':
         'name': 'storage.type.trait.php'
@@ -61,7 +61,7 @@
     ]
   }
   {
-    'match': '(?i)(?:^|(?<=<\\?php))\\s*(namespace)\\s+([a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)(?=\\s*;)'
+    'match': '(?i)(?:^|(?<=<\\?php))\\s*(namespace)\\s+([a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)(?=\\s*;)'
     'name': 'meta.namespace.php'
     'captures':
       '1':
@@ -87,7 +87,7 @@
         'include': '#comments'
       }
       {
-        'match': '(?i)[a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+'
+        'match': '(?i)[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+'
         'name': 'entity.name.type.namespace.php'
         'captures':
           '0':
@@ -151,7 +151,7 @@
             'match': '''(?xi)
               \\b(as)
               \\s+(final|abstract|public|private|protected|static)
-              \\s+([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)
+              \\s+([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)
             '''
             'captures':
               '1':
@@ -164,7 +164,7 @@
           {
             'match': '''(?xi)
               \\b(as)
-              \\s+([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)
+              \\s+([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)
             '''
             'captures':
               '1':
@@ -182,7 +182,7 @@
                 ]
           }
           {
-            'match': '(?i)\\b(insteadof)\\s+([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)'
+            'match': '(?i)\\b(insteadof)\\s+([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)'
             'captures':
               '1':
                 'name': 'keyword.other.use-insteadof.php'
@@ -206,7 +206,7 @@
   {
     'begin':  '''(?ix)
         (?:
-          \\b(?:(abstract|final)\\s+)?(class)\\s+([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)
+          \\b(?:(abstract|final)\\s+)?(class)\\s+([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)
           |\\b(new)\\b\\s*(\\#\\[.*\\])?\\s*\\b(class)\\b # anonymous class
         )
       '''
@@ -242,11 +242,11 @@
           '1':
             'name': 'storage.modifier.extends.php'
         'contentName': 'meta.other.inherited-class.php'
-        'end': '(?i)(?=[^a-z0-9_\\x{7f}-\\x{7fffffff}\\\\])'
+        'end': '(?i)(?=[^a-z0-9_\\x{7f}-\\x{10ffff}\\\\])'
         'patterns': [
           {
-            'begin': '(?i)(?=\\\\?[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*\\\\)'
-            'end': '(?i)([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?(?=[^a-z0-9_\\x{7f}-\\x{7fffffff}\\\\])'
+            'begin': '(?i)(?=\\\\?[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*\\\\)'
+            'end': '(?i)([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)?(?=[^a-z0-9_\\x{7f}-\\x{10ffff}\\\\])'
             'endCaptures':
               '1':
                 'name': 'entity.other.inherited-class.php'
@@ -263,7 +263,7 @@
             'include': '#namespace'
           }
           {
-            'match': '(?i)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*'
+            'match': '(?i)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*'
             'name': 'entity.other.inherited-class.php'
           }
         ]
@@ -279,13 +279,13 @@
             'include': '#comments'
           }
           {
-            'begin': '(?i)(?=[a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)'
+            'begin': '(?i)(?=[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)'
             'contentName': 'meta.other.inherited-class.php'
-            'end': '(?i)(?:\\s*(?:,|(?=[^a-z0-9_\\x{7f}-\\x{7fffffff}\\\\\\s]))\\s*)'
+            'end': '(?i)(?:\\s*(?:,|(?=[^a-z0-9_\\x{7f}-\\x{10ffff}\\\\\\s]))\\s*)'
             'patterns': [
               {
-                'begin': '(?i)(?=\\\\?[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*\\\\)'
-                'end': '(?i)([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?(?=[^a-z0-9_\\x{7f}-\\x{7fffffff}\\\\])'
+                'begin': '(?i)(?=\\\\?[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*\\\\)'
+                'end': '(?i)([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)?(?=[^a-z0-9_\\x{7f}-\\x{10ffff}\\\\])'
                 'endCaptures':
                   '1':
                     'name': 'entity.other.inherited-class.php'
@@ -302,7 +302,7 @@
                 'include': '#namespace'
               }
               {
-                'match': '(?i)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*'
+                'match': '(?i)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*'
                 'name': 'entity.other.inherited-class.php'
               }
             ]
@@ -378,9 +378,9 @@
     'patterns': [
       {
         'match': '''(?xi)
-          ([a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)*) # union or single exception class
+          ([a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)*) # union or single exception class
           \\s*
-          ((\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?           # Variable
+          ((\\$+)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)?           # Variable
         '''
         'captures':
           '1':
@@ -390,10 +390,10 @@
                 'name': 'punctuation.separator.delimiter.php'
               }
               {
-                'begin': '(?i)(?=[\\\\a-z_\\x{7f}-\\x{7fffffff}])'
+                'begin': '(?i)(?=[\\\\a-z_\\x{7f}-\\x{10ffff}])'
                 'end': '''(?xi)
-                  ( [a-z_\\x{7f}-\\x{7fffffff}] [a-z0-9_\\x{7f}-\\x{7fffffff}]* )
-                  (?![a-z0-9_\\x{7f}-\\x{7fffffff}\\\\])
+                  ( [a-z_\\x{7f}-\\x{10ffff}] [a-z0-9_\\x{7f}-\\x{10ffff}]* )
+                  (?![a-z0-9_\\x{7f}-\\x{10ffff}\\\\])
                 '''
                 'endCaptures':
                   '1':
@@ -470,7 +470,7 @@
                 'name': 'storage.modifier.reference.php'
               '3':
                 'name': 'punctuation.definition.variable.php'
-            'match': '(?i)((?:(&)\\s*)?(\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)\\s*(?=,|\\))'
+            'match': '(?i)((?:(&)\\s*)?(\\$+)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)\\s*(?=,|\\))'
           }
         ]
       }
@@ -478,8 +478,8 @@
         'match': '''(?xi)
           (:)\\s*
           (
-            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
-            [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
+            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |                                        # nullable type
+            [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ # union type
           )
           (?=\\s*(?:{|/[/*]|\\#|$))
         '''
@@ -528,8 +528,8 @@
         'match': '''(?xi)
           (:)\\s*
           (
-            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
-            [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
+            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |                                        # nullable type
+            [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ # union type
           )
           (?=\\s*(?:=>|/[/*]|\\#|$))
         '''
@@ -569,7 +569,7 @@
     'contentName': 'meta.function.parameters.php'
     'end': '''(?xi)
       (\\)) \\s* ( : \\s*
-        (?:\\?\\s*)? (?!\\s) [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\\\s\\|&]+ (?<!\\s)
+        (?:\\?\\s*)? (?!\\s) [a-z0-9_\\x{7f}-\\x{10ffff}\\\\\\s\\|&]+ (?<!\\s)
       )?
       (?=\\s*(?:{|/[/*]|\\#|$|;))
     '''
@@ -592,10 +592,10 @@
         'begin': '''(?xi)
           ((?:(?:public|private|protected|readonly)(?:\\s+|(?=\\?)))++)
           (?: (
-            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
-            [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
+            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |                                        # nullable type
+            [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ # union type
           ) \\s+ )?
-          ((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable name with possible reference
+          ((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*) # Variable name with possible reference
         '''
         'beginCaptures':
           '1':
@@ -647,7 +647,7 @@
       (?i:
         (__(?:call|construct|debugInfo|destruct|get|set|isset|unset|toString|
               clone|set_state|sleep|wakeup|autoload|invoke|callStatic|serialize|unserialize))
-        |(?:(&)?\\s*([a-zA-Z_\\x{7f}-\\x{7fffffff}][a-zA-Z0-9_\\x{7f}-\\x{7fffffff}]*))
+        |(?:(&)?\\s*([a-zA-Z_\\x{7f}-\\x{10ffff}][a-zA-Z0-9_\\x{7f}-\\x{10ffff}]*))
       )
       \\s*(\\()
     '''
@@ -672,8 +672,8 @@
     'contentName': 'meta.function.parameters.php'
     'end': '''(?xi)
       (\\)) (?: \\s* (:) \\s* (
-        (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
-        [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
+        (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |                                        # nullable type
+        [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ # union type
       ) )?
       (?=\\s*(?:{|/[/*]|\\#|$|;))
     '''
@@ -708,10 +708,10 @@
     'match': '''(?xi)
       ((?:(?:public|private|protected|static|readonly)(?:\\s+|(?=\\?)))++)                     # At least one modifier
       (
-        (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
-        [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
+        (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |                                        # nullable type
+        [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ # union type
       )?
-      \\s+ ((\\$)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)          # Variable name
+      \\s+ ((\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)          # Variable name
     '''
     'captures':
       '1':
@@ -874,7 +874,7 @@
     'beginCaptures':
       '1':
         'name': 'keyword.operator.type.php'
-    'end': '(?i)(?=[^\\\\$a-z0-9_\\x{7f}-\\x{7fffffff}])'
+    'end': '(?i)(?=[^\\\\$a-z0-9_\\x{7f}-\\x{10ffff}])'
     'patterns': [
       {
         'include': '#class-name'
@@ -893,13 +893,13 @@
         'name': 'keyword.control.goto.php'
       '2':
         'name': 'support.other.php'
-    'match': '(?i)(goto)\\s+([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)'
+    'match': '(?i)(goto)\\s+([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)'
   }
   {
     'captures':
       '1':
         'name': 'entity.name.goto-label.php'
-    'match': '(?i)^\\s*([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)\\s*:(?!:)'
+    'match': '(?i)^\\s*([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)\\s*:(?!:)'
   }
   {
     'include': '#string-backtick'
@@ -970,10 +970,10 @@
   'attribute-name':
     'patterns': [
       {
-        'begin': '(?i)(?=\\\\?[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*\\\\)'
+        'begin': '(?i)(?=\\\\?[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*\\\\)'
         'end': '''(?xi)
-          ( [a-z_\\x{7f}-\\x{7fffffff}] [a-z0-9_\\x{7f}-\\x{7fffffff}]* )?
-          (?![a-z0-9_\\x{7f}-\\x{7fffffff}\\\\])
+          ( [a-z_\\x{7f}-\\x{10ffff}] [a-z0-9_\\x{7f}-\\x{10ffff}]* )?
+          (?![a-z0-9_\\x{7f}-\\x{10ffff}\\\\])
         '''
         'endCaptures':
           '1':
@@ -995,10 +995,10 @@
             'name': 'punctuation.separator.inheritance.php'
       }
       {
-        'begin': '(?i)(?=[\\\\a-z_\\x{7f}-\\x{7fffffff}])'
+        'begin': '(?i)(?=[\\\\a-z_\\x{7f}-\\x{10ffff}])'
         'end': '''(?xi)
-          ( [a-z_\\x{7f}-\\x{7fffffff}] [a-z0-9_\\x{7f}-\\x{7fffffff}]* )?
-          (?![a-z0-9_\\x{7f}-\\x{7fffffff}\\\\])
+          ( [a-z_\\x{7f}-\\x{10ffff}] [a-z0-9_\\x{7f}-\\x{10ffff}]* )?
+          (?![a-z0-9_\\x{7f}-\\x{10ffff}\\\\])
         '''
         'endCaptures':
           '1':
@@ -1020,7 +1020,7 @@
         'name': 'punctuation.separator.delimiter.php'
       }
       {
-        'begin': '([a-zA-Z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)\\s*(\\()'
+        'begin': '([a-zA-Z0-9_\\x{7f}-\\x{10ffff}\\\\]+)\\s*(\\()'
         'beginCaptures':
           '1':
             'patterns': [
@@ -1118,10 +1118,10 @@
   'class-name':
     'patterns': [
       {
-        'begin': '(?i)(?=\\\\?[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*\\\\)'
+        'begin': '(?i)(?=\\\\?[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*\\\\)'
         'end': '''(?xi)
-          ( [a-z_\\x{7f}-\\x{7fffffff}] [a-z0-9_\\x{7f}-\\x{7fffffff}]* )?
-          (?![a-z0-9_\\x{7f}-\\x{7fffffff}\\\\])
+          ( [a-z_\\x{7f}-\\x{10ffff}] [a-z0-9_\\x{7f}-\\x{10ffff}]* )?
+          (?![a-z0-9_\\x{7f}-\\x{10ffff}\\\\])
         '''
         'endCaptures':
           '1':
@@ -1136,10 +1136,10 @@
         'include': '#class-builtin'
       }
       {
-        'begin': '(?i)(?=[\\\\a-z_\\x{7f}-\\x{7fffffff}])'
+        'begin': '(?i)(?=[\\\\a-z_\\x{7f}-\\x{10ffff}])'
         'end': '''(?xi)
-          ( [a-z_\\x{7f}-\\x{7fffffff}] [a-z0-9_\\x{7f}-\\x{7fffffff}]* )?
-          (?![a-z0-9_\\x{7f}-\\x{7fffffff}\\\\])
+          ( [a-z_\\x{7f}-\\x{10ffff}] [a-z0-9_\\x{7f}-\\x{10ffff}]* )?
+          (?![a-z0-9_\\x{7f}-\\x{10ffff}\\\\])
         '''
         'endCaptures':
           '1':
@@ -1420,7 +1420,7 @@
         # In PHP, any identifier which is not a variable is taken to be a constant.
         # However, if there is not a constant defined with the given name then a notice
         # is generated and the constant is assumed to have the value of its name.
-        'match': '(?i)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*'
+        'match': '(?i)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*'
         'name': 'constant.other.php'
       }
     ]
@@ -1440,10 +1440,10 @@
         # Variadic
         'match': '''(?xi)
           (?: (
-            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
-            [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
+            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |                                        # nullable type
+            [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ # union type
           ) \\s+ )?
-          ((?:(&)\\s*)?(\\.\\.\\.)(\\$)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable name with possible reference
+          ((?:(&)\\s*)?(\\.\\.\\.)(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*) # Variable name with possible reference
           (?=\\s*(?:,|\\)|/[/*]|\\#|$)) # A closing parentheses (end of argument list) or a comma or a comment
         '''
         'captures':
@@ -1467,10 +1467,10 @@
         # Typehinted
         'begin': '''(?xi)
           (
-            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type
-            [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type
+            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |                                        # nullable type
+            [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ # union type
           )
-          \\s+ ((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable name with possible reference
+          \\s+ ((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*) # Variable name with possible reference
         '''
         'beginCaptures':
           '1':
@@ -1504,7 +1504,7 @@
       }
       {
         'match': '''(?xi)
-          ((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable name with possible reference
+          ((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*) # Variable name with possible reference
           (?=\\s*(?:,|\\)|/[/*]|\\#|$)) # A closing parentheses (end of argument list) or a comma or a comment
         '''
         'captures':
@@ -1518,7 +1518,7 @@
       }
       {
         'begin': '''(?xi)
-          ((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable name with possible reference
+          ((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*) # Variable name with possible reference
           \\s*(=)\\s*
         '''
         'beginCaptures':
@@ -1540,7 +1540,7 @@
       }
     ]
   'named-arguments':
-    'match': '(?i)(?<=^|\\(|,)\\s*([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)\\s*(:)(?!:)'
+    'match': '(?i)(?<=^|\\(|,)\\s*([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)\\s*(:)(?!:)'
     'captures':
       '1':
         'name': 'entity.name.variable.parameter.php'
@@ -1552,9 +1552,9 @@
         # Functions in a user-defined namespace (overrides any built-ins)
         'begin': '''(?xi)
           (
-            \\\\?(?<![a-z0-9_\\x{7f}-\\x{7fffffff}])                            # Optional root namespace
-            [a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*          # First namespace
-            (?:\\\\[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)+ # Additional namespaces
+            \\\\?(?<![a-z0-9_\\x{7f}-\\x{10ffff}])                            # Optional root namespace
+            [a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*          # First namespace
+            (?:\\\\[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)+ # Additional namespaces
           )\\s*(\\()
         '''
         'beginCaptures':
@@ -1564,7 +1564,7 @@
                 'include': '#namespace'
               }
               {
-                'match': '(?i)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*'
+                'match': '(?i)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*'
                 'name': 'entity.name.function.php'
               }
             ]
@@ -1586,7 +1586,7 @@
       }
       {
         # Root namespace function calls (built-in or user)
-        'begin': '(?i)(\\\\)?(?<![a-z0-9_\\x{7f}-\\x{7fffffff}])([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)\\s*(\\()'
+        'begin': '(?i)(\\\\)?(?<![a-z0-9_\\x{7f}-\\x{10ffff}])([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)\\s*(\\()'
         'beginCaptures':
           '1':
             'patterns': [
@@ -1600,7 +1600,7 @@
                 'include': '#support'
               }
               {
-                'match': '(?i)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*'
+                'match': '(?i)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*'
                 'name': 'entity.name.function.php'
               }
             ]
@@ -1628,7 +1628,7 @@
   'heredoc':
     'patterns': [
       {
-        'begin': '(?i)(?=<<<\\s*("?)([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)(\\1)\\s*$)'
+        'begin': '(?i)(?=<<<\\s*("?)([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)(\\1)\\s*$)'
         'end': '(?!\\G)'
         'name': 'string.unquoted.heredoc.php'
         'patterns': [
@@ -1662,7 +1662,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'text.html'
-        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1690,7 +1690,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'text.xml'
-        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1718,7 +1718,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.sql'
-        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1746,7 +1746,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.js'
-        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1774,7 +1774,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.json'
-        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1802,7 +1802,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.css'
-        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1830,7 +1830,7 @@
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'string.regexp.heredoc.php'
-        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1875,7 +1875,7 @@
           {
             # We are restrictive in what we allow to go after the comment to avoid false positives,
             # since the availability of comments depend on regexp flags.
-            'begin': '(?i)(?<=^|\\s)(#)\\s(?=[[a-z0-9_\\x{7f}-\\x{7fffffff},. \\t?!-][^\\x{00}-\\x{7f}]]*$)'
+            'begin': '(?i)(?<=^|\\s)(#)\\s(?=[[a-z0-9_\\x{7f}-\\x{10ffff},. \\t?!-][^\\x{00}-\\x{7f}]]*$)'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.comment.php'
@@ -1888,7 +1888,7 @@
         ]
       }
       {
-        'begin': '(?i)(<<<)\\s*("?)([a-z_\\x{7f}-\\x{7fffffff}]+[a-z0-9_\\x{7f}-\\x{7fffffff}]*)(\\2)(\\s*)'
+        'begin': '(?i)(<<<)\\s*("?)([a-z_\\x{7f}-\\x{10ffff}]+[a-z0-9_\\x{7f}-\\x{10ffff}]*)(\\2)(\\s*)'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.string.php'
@@ -1896,7 +1896,7 @@
             'name': 'keyword.operator.heredoc.php'
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
-        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '1':
             'name': 'keyword.operator.heredoc.php'
@@ -1921,7 +1921,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'text.html'
-        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1946,7 +1946,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'text.xml'
-        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1971,7 +1971,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.sql'
-        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -1996,7 +1996,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.js'
-        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -2021,7 +2021,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.json'
-        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -2046,7 +2046,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'source.css'
-        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -2071,7 +2071,7 @@
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
         'contentName': 'string.regexp.nowdoc.php'
-        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':
             'name': 'punctuation.section.embedded.end.php'
@@ -2113,7 +2113,7 @@
           {
             # We are restrictive in what we allow to go after the comment to avoid false positives,
             # since the availability of comments depend on regexp flags.
-            'begin': '(?i)(?<=^|\\s)(#)\\s(?=[[a-z0-9_\\x{7f}-\\x{7fffffff},. \\t?!-][^\\x{00}-\\x{7f}]]*$)'
+            'begin': '(?i)(?<=^|\\s)(#)\\s(?=[[a-z0-9_\\x{7f}-\\x{10ffff},. \\t?!-][^\\x{00}-\\x{7f}]]*$)'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.comment.php'
@@ -2126,7 +2126,7 @@
         ]
       }
       {
-        'begin': '(?i)(<<<)\\s*\'([a-z_\\x{7f}-\\x{7fffffff}]+[a-z0-9_\\x{7f}-\\x{7fffffff}]*)\'(\\s*)'
+        'begin': '(?i)(<<<)\\s*\'([a-z_\\x{7f}-\\x{10ffff}]+[a-z0-9_\\x{7f}-\\x{10ffff}]*)\'(\\s*)'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.string.php'
@@ -2134,7 +2134,7 @@
             'name': 'keyword.operator.nowdoc.php'
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
-        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '1':
             'name': 'keyword.operator.nowdoc.php'
@@ -2145,10 +2145,10 @@
     'beginCaptures':
       '1':
         'name': 'keyword.other.new.php'
-    'end': '(?i)(?=[^a-z0-9_\\x{7f}-\\x{7fffffff}\\\\])'
+    'end': '(?i)(?=[^a-z0-9_\\x{7f}-\\x{10ffff}\\\\])'
     'patterns': [
       {
-        'match': '(?i)(parent|static|self)(?![a-z0-9_\\x{7f}-\\x{7fffffff}])'
+        'match': '(?i)(parent|static|self)(?![a-z0-9_\\x{7f}-\\x{10ffff}])'
         'name': 'storage.type.php'
       }
       {
@@ -2213,16 +2213,16 @@
         'name': 'variable.other.php'
       '2':
         'name': 'punctuation.definition.variable.php'
-    'match': '(?i)((\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)(?=\\s*\\()'
+    'match': '(?i)((\\$+)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)(?=\\s*\\()'
     'name': 'meta.function-call.invoke.php'
   'namespace':
-    'begin': '(?i)(?:(namespace)|[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?(\\\\)'
+    'begin': '(?i)(?:(namespace)|[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)?(\\\\)'
     'beginCaptures':
       '1':
         'name': 'variable.language.namespace.php'
       '2':
         'name': 'punctuation.separator.inheritance.php'
-    'end': '(?i)(?![a-z0-9_\\x{7f}-\\x{7fffffff}]*\\\\)'
+    'end': '(?i)(?![a-z0-9_\\x{7f}-\\x{10ffff}]*\\\\)'
     'name': 'support.other.namespace.php'
     'patterns': [
       {
@@ -2288,7 +2288,7 @@
         ]
       }
       {
-        'begin': '(?i)(\\??->)\\s*([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)\\s*(\\()'
+        'begin': '(?i)(\\??->)\\s*([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)\\s*(\\()'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.class.php'
@@ -2318,7 +2318,7 @@
             'name': 'variable.other.property.php'
           '3':
             'name': 'punctuation.definition.variable.php'
-        'match': '(?i)(\\??->)\\s*((\\$+)?[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?'
+        'match': '(?i)(\\??->)\\s*((\\$+)?[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)?'
       }
     ]
   'php-types':
@@ -2409,11 +2409,11 @@
       }
       {
         'begin': '''(?xi)
-          (?=[a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+
-            (::)\\s*([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?
+          (?=[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+
+            (::)\\s*([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)?
           )
         '''
-        'end': '(?i)(::)\\s*([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)?'
+        'end': '(?i)(::)\\s*([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)?'
         'endCaptures':
           '1':
             'name': 'keyword.operator.class.php'
@@ -2457,7 +2457,7 @@
       {
         # Tags followed by a type expression
         # -  @<tag> type
-        'begin': '(@(?:global|param|property(-(read|write))?|return|throws|var))\\s+(?=[A-Za-z_\\x{7f}-\\x{7fffffff}\\\\]|\\()'
+        'begin': '(@(?:global|param|property(-(read|write))?|return|throws|var))\\s+(?=[A-Za-z_\\x{7f}-\\x{10ffff}\\\\]|\\()'
         'beginCaptures':
           '1':
             'name': 'keyword.other.phpdoc.php'
@@ -2495,7 +2495,7 @@
       }
     ]
   'php_doc_types':
-    'match': '(?i)[a-z_\\x{7f}-\\x{7fffffff}\\\\][a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]*([|&][a-z_\\x{7f}-\\x{7fffffff}\\\\][a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]*)*'
+    'match': '(?i)[a-z_\\x{7f}-\\x{10ffff}\\\\][a-z0-9_\\x{7f}-\\x{10ffff}\\\\]*([|&][a-z_\\x{7f}-\\x{10ffff}\\\\][a-z0-9_\\x{7f}-\\x{10ffff}\\\\]*)*'
     'captures':
       '0':
         'patterns': [
@@ -2543,7 +2543,7 @@
     ]
   'php_doc_types_array_single':
     # Singular type array: int[]
-    'match': '(?i)([a-z_\\x{7f}-\\x{7fffffff}\\\\][a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]*)(\\[\\])'
+    'match': '(?i)([a-z_\\x{7f}-\\x{10ffff}\\\\][a-z0-9_\\x{7f}-\\x{10ffff}\\\\]*)(\\[\\])'
     'captures':
       '1':
         'patterns': [
@@ -2638,7 +2638,7 @@
   'scope-resolution':
     'patterns': [
       {
-        'match': '(?i)([a-z_\\x{7f}-\\x{7fffffff}\\\\][a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]*)(?=\\s*::)'
+        'match': '(?i)([a-z_\\x{7f}-\\x{10ffff}\\\\][a-z0-9_\\x{7f}-\\x{10ffff}\\\\]*)(?=\\s*::)'
         'captures':
           '1':
             'patterns': [
@@ -2655,7 +2655,7 @@
             ]
       }
       {
-        'begin': '(?i)(::)\\s*([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)\\s*(\\()'
+        'begin': '(?i)(::)\\s*([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)\\s*(\\()'
         'beginCaptures':
           '1':
             'name': 'keyword.operator.class.php'
@@ -2689,9 +2689,9 @@
         'match': '''(?xi)
           (::)\\s*
           (?:
-            ((\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*) # Variable
+            ((\\$+)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*) # Variable
             |
-            ([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)       # Constant
+            ([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)       # Constant
           )?
         '''
         'captures':
@@ -3873,7 +3873,7 @@
         'beginCaptures':
           '1':
             'name': 'keyword.other.use-as.php'
-        'end': '(?i)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*'
+        'end': '(?i)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*'
         'endCaptures':
           '0':
             'name': 'entity.other.alias.php'
@@ -3889,7 +3889,7 @@
   'var_basic':
     'patterns': [
       {
-        'match': '(?i)(\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*'
+        'match': '(?i)(\\$+)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*'
         'name': 'variable.other.php'
         'captures':
           '1':
@@ -3946,11 +3946,11 @@
             'name': 'punctuation.section.array.end.php'
         # Simple syntax: $foo, $foo[0], $foo[$bar], $foo->bar
         'match': '''(?xi)
-          ((\\$)(?<name>[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*))\\s*
+          ((\\$)(?<name>[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*))\\s*
           (?:
             (\\??->)\\s*(\\g<name>)
             |
-            (\\[)(?:(\\d+)|((\\$)\\g<name>)|([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*))(\\])
+            (\\[)(?:(\\d+)|((\\$)\\g<name>)|([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*))(\\])
           )?
         '''
       }
@@ -3963,7 +3963,7 @@
           '4':
             'name': 'punctuation.definition.variable.php'
         # Simple syntax with braces: foo${bar}baz
-        'match': '(?i)((\\${)(?<name>[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)(}))'
+        'match': '(?i)((\\${)(?<name>[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)(}))'
       }
     ]
   'variables':
@@ -4012,7 +4012,7 @@
       {
         # prevent matching goto label in ternary
         # See https://github.com/atom/language-php/issues/386
-        'match': '(?i)^\\s*([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)\\s*(?=:(?!:))'
+        'match': '(?i)^\\s*([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)\\s*(?=:(?!:))'
         'captures':
           '1':
             'patterns': [


### PR DESCRIPTION
### Requirements

This change limits valid characters recognized to 0x10FFFF according to UTF-8 specification.

### Description of the Change

This is to make the regular expressions PCRE-compliant, where matched characters should not fall out of UTF-8 bounds: https://www.pcre.org/original/doc/html/pcreunicode.html
Since UTF-8 is a standard encoding for PHP files according to [PSR-1](https://www.php-fig.org/psr/psr-1/), I don't see a point supporting any invalid Unicode characters.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

The reason for this change is actually to make GitHub Linguist support this grammar as it sticks to strict PCRE rules.

[Before](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fatom%2Flanguage-php%2Fblob%2Fmaster%2Fgrammars%2Fphp.cson&grammar_text=&code_source=from-text&code_url=&code=%3C%3Fphp%0D%0A%0D%0A%23%5BAttribute%5D%0D%0Aclass+Test+%7B%0D%0A%09function+__construct%28array+%24data%29+%7B%7D%0D%0A%7D%0D%0A%0D%0Afunction+method%28%23%5BTest%28%5B%27value%27+%3D%3E+true%5D%29%5D+%24data%29+%7B%7D+%2F%2F+%3C-----+here)
![image](https://user-images.githubusercontent.com/1985514/138267001-23168d94-9b51-4a7f-89f8-3df7cafb3df7.png)

[After](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2FIonBazan%2Flanguage-php%2Fblob%2Futf-8-compliance%2Fgrammars%2Fphp.cson&grammar_text=&code_source=from-text&code_url=&code=%3C%3Fphp%0D%0A%0D%0A%23%5BAttribute%5D%0D%0Aclass+Test+%7B%0D%0A%09function+__construct%28array+%24data%29+%7B%7D%0D%0A%7D%0D%0A%0D%0Afunction+method%28%23%5BTest%28%5B%27value%27+%3D%3E+true%5D%29%5D+%24data%29+%7B%7D+%2F%2F+%3C-----+here)

![image](https://user-images.githubusercontent.com/1985514/138266892-f1a84302-5644-4626-9b45-5adc272a148c.png)


### Possible Drawbacks

Any invalid character will stop being recognized as a variable name but that shouldn't occur in real world.

### Applicable Issues

https://github.com/github/linguist/issues/5522


While awaiting for workflow run approval, let me just confirm that tests are passing locally.