### PR TITLE
Detect nullable types in phpdoc

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2457,7 +2457,7 @@
       {
         # Tags followed by a type expression
         # -  @<tag> type
-        'begin': '(@(?:global|param|property(-(read|write))?|return|throws|var))\\s+(?=[A-Za-z_\\x{7f}-\\x{7fffffff}\\\\]|\\()'
+        'begin': '(@(?:global|param|property(-(read|write))?|return|throws|var))\\s+(?=[?A-Za-z_\\x{7f}-\\x{7fffffff}\\\\]|\\()'
         'beginCaptures':
           '1':
             'name': 'keyword.other.phpdoc.php'
@@ -2495,7 +2495,7 @@
       }
     ]
   'php_doc_types':
-    'match': '(?i)[a-z_\\x{7f}-\\x{7fffffff}\\\\][a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]*([|&][a-z_\\x{7f}-\\x{7fffffff}\\\\][a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]*)*'
+    'match': '(?i)\\??[a-z_\\x{7f}-\\x{7fffffff}\\\\][a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]*([|&]\\??[a-z_\\x{7f}-\\x{7fffffff}\\\\][a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]*)*'
     'captures':
       '0':
         'patterns': [

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2500,6 +2500,10 @@
       '0':
         'patterns': [
           {
+            'match': '\\?'
+            'name': 'keyword.operator.nullable-type.php'
+          }
+          {
             'match': '''(?x)\\b
               (string|integer|int|boolean|bool|float|double|object|mixed
               |array|resource|void|null|callback|false|true|self|static)\\b

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -2569,7 +2569,7 @@ describe 'PHP grammar', ->
 
         expect(lines[1][1]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(lines[1][2]).toEqual value: ' ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
-        expect(lines[1][3]).toEqual value: '?', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php']
+        expect(lines[1][3]).toEqual value: '?', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.operator.nullable-type.php']
         expect(lines[1][4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
         expect(lines[1][5]).toEqual value: ' description', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
 
@@ -2580,7 +2580,7 @@ describe 'PHP grammar', ->
 
         expect(lines[1][1]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(lines[1][2]).toEqual value: ' ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
-        expect(lines[1][3]).toEqual value: '?', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php']
+        expect(lines[1][3]).toEqual value: '?', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.operator.nullable-type.php']
         expect(lines[1][4]).toEqual value: 'Test', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'support.class.php']
         expect(lines[1][5]).toEqual value: ' description', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
 
@@ -2619,10 +2619,10 @@ describe 'PHP grammar', ->
 
         expect(lines[1][1]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(lines[1][2]).toEqual value: ' ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
-        expect(lines[1][3]).toEqual value: '?', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php']
+        expect(lines[1][3]).toEqual value: '?', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.operator.nullable-type.php']
         expect(lines[1][4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
         expect(lines[1][5]).toEqual value: '|', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'punctuation.separator.delimiter.php']
-        expect(lines[1][6]).toEqual value: '?', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php']
+        expect(lines[1][6]).toEqual value: '?', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.operator.nullable-type.php']
         expect(lines[1][7]).toEqual value: 'Class', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'support.class.php']
         expect(lines[1][8]).toEqual value: ' description', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
 

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -2561,6 +2561,29 @@ describe 'PHP grammar', ->
         expect(lines[1][3]).toEqual value: 'Test', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'support.class.php']
         expect(lines[1][4]).toEqual value: ' description', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
 
+      it 'should tokenize a single nullable type', ->
+        lines = grammar.tokenizeLines '''
+          /**
+          *@param ?int description
+        '''
+
+        expect(lines[1][1]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(lines[1][2]).toEqual value: ' ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
+        expect(lines[1][3]).toEqual value: '?', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php']
+        expect(lines[1][4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(lines[1][5]).toEqual value: ' description', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
+
+        lines = grammar.tokenizeLines '''
+          /**
+          *@param ?Test description
+        '''
+
+        expect(lines[1][1]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(lines[1][2]).toEqual value: ' ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
+        expect(lines[1][3]).toEqual value: '?', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php']
+        expect(lines[1][4]).toEqual value: 'Test', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'support.class.php']
+        expect(lines[1][5]).toEqual value: ' description', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
+
       it 'should tokenize a single namespaced type', ->
         lines = grammar.tokenizeLines '''
           /**
@@ -2587,6 +2610,21 @@ describe 'PHP grammar', ->
         expect(lines[1][4]).toEqual value: '|', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'punctuation.separator.delimiter.php']
         expect(lines[1][5]).toEqual value: 'Class', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'support.class.php']
         expect(lines[1][6]).toEqual value: ' description', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
+
+      it 'should tokenize multiple nullable types', ->
+        lines = grammar.tokenizeLines '''
+          /**
+          *@param ?int|?Class description
+        '''
+
+        expect(lines[1][1]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(lines[1][2]).toEqual value: ' ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
+        expect(lines[1][3]).toEqual value: '?', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php']
+        expect(lines[1][4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(lines[1][5]).toEqual value: '|', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'punctuation.separator.delimiter.php']
+        expect(lines[1][6]).toEqual value: '?', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php']
+        expect(lines[1][7]).toEqual value: 'Class', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'support.class.php']
+        expect(lines[1][8]).toEqual value: ' description', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
 
       it 'should tokenize intersection types', ->
         lines = grammar.tokenizeLines '''


### PR DESCRIPTION
### Description of the Change

Allow the following syntaxes in phpdoc:
```php
/**
 * @param ?int description
 */
```
```php
/**
 * @param ?int|?Class description
 */
```
```php
/**
 * @param ?int[] description
 */
```

### Alternate Designs

I am not aware of any other alternatives.

### Benefits

Allow the new nullable type syntax.

### Possible Drawbacks

Not aware of any drawbacks. The change is minor.

### Applicable Issues

That is a step towards solving the need [in this issue](https://github.com/atom/language-php/issues/430).

### Note

That is my first pull request to this repo. It's purpose is to be something small that will allow me to learn how to do effective PRs here - learn the rules and pracices, set up the tooling.

My main goal is to ultimately add detection for:
* Psalm complex array types
* PHPStan comments (@phpstan-ignore-line)
* PHPUnit attributes (@test, @dataProvider, etc.)