### PR TITLE
feat: Add php enum

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -206,7 +206,7 @@
   {
     'begin':  '''(?ix)
         (?:
-          \\b(?:(abstract|final)\\s+)?(class)\\s+([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)
+          \\b(?:(abstract|final)\\s+)?(class|enum)\\s+([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)
           |\\b(new)\\b\\s*(\\#\\[.*\\])?\\s*\\b(class)\\b # anonymous class
         )
       '''


### PR DESCRIPTION
### Description of the Change

This PR adds support for PHP 8.1 enums

### Benefits

Adds syntax coloration for enums for those using php 8.1

### Possible Drawbacks

None as far as I've tested.

### Applicable Issues

None at this moment.
