### PR TITLE
Add DQL support

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1707,7 +1707,7 @@
         ]
       }
       {
-        'begin': '(<<<)\\s*("?)((D|S)QL)(\\2)(\\s*)$'
+        'begin': '(<<<)\\s*("?)([DS]QL)(\\2)(\\s*)$'
         'beginCaptures':
           '0':
             'name': 'punctuation.section.embedded.begin.php'
@@ -1985,7 +1985,7 @@
         ]
       }
       {
-        'begin': '(<<<)\\s*\'((D|S)QL)\'(\\s*)$'
+        'begin': '(<<<)\\s*\'([DS]QL)\'(\\s*)$'
         'beginCaptures':
           '0':
             'name': 'punctuation.section.embedded.begin.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1707,7 +1707,7 @@
         ]
       }
       {
-        'begin': '(<<<)\\s*("?)(SQL)(\\2)(\\s*)$'
+        'begin': '(<<<)\\s*("?)((D|S)QL)(\\2)(\\s*)$'
         'beginCaptures':
           '0':
             'name': 'punctuation.section.embedded.begin.php'
@@ -1985,7 +1985,7 @@
         ]
       }
       {
-        'begin': '(<<<)\\s*\'(SQL)\'(\\s*)$'
+        'begin': '(<<<)\\s*\'((D|S)QL)\'(\\s*)$'
         'beginCaptures':
           '0':
             'name': 'punctuation.section.embedded.begin.php'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -3450,6 +3450,74 @@ describe 'PHP grammar', ->
       expect(lines[2][0]).toEqual value: 'SQL', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.nowdoc.php']
       expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
+  it 'should tokenize a heredoc with embedded DQL correctly', ->
+    waitsForPromise ->
+      atom.packages.activatePackage('language-sql')
+
+    runs ->
+      lines = grammar.tokenizeLines '''
+        $a = <<<DQL
+        SELECT * FROM table
+        DQL;
+      '''
+
+      expect(lines[0][0]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(lines[0][1]).toEqual value: 'a', scopes: ['source.php', 'variable.other.php']
+      expect(lines[0][2]).toEqual value: ' ', scopes: ['source.php']
+      expect(lines[0][3]).toEqual value: '=', scopes: ['source.php', 'keyword.operator.assignment.php']
+      expect(lines[0][4]).toEqual value: ' ', scopes: ['source.php']
+      expect(lines[0][5]).toEqual value: '<<<', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.begin.php', 'punctuation.definition.string.php']
+      expect(lines[0][6]).toEqual value: 'DQL', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.begin.php', 'keyword.operator.heredoc.php']
+      expect(lines[1][0].value).toEqual 'SELECT'
+      expect(lines[1][0].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+      expect(lines[1][1].value).toEqual ' '
+      expect(lines[1][1].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+      expect(lines[1][2].value).toEqual '*'
+      expect(lines[1][2].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+      expect(lines[1][3].value).toEqual ' '
+      expect(lines[1][3].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+      expect(lines[1][4].value).toEqual 'FROM'
+      expect(lines[1][4].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+      expect(lines[1][5].value).toEqual ' table'
+      expect(lines[1][5].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+      expect(lines[2][0]).toEqual value: 'DQL', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.heredoc.php']
+      expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+
+  it 'should tokenize a nowdoc with embedded DQL correctly', ->
+    waitsForPromise ->
+      atom.packages.activatePackage('language-sql')
+
+    runs ->
+      lines = grammar.tokenizeLines '''
+        $a = <<<'DQL'
+        SELECT * FROM table
+        DQL;
+      '''
+
+      expect(lines[0][0]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(lines[0][1]).toEqual value: 'a', scopes: ['source.php', 'variable.other.php']
+      expect(lines[0][2]).toEqual value: ' ', scopes: ['source.php']
+      expect(lines[0][3]).toEqual value: '=', scopes: ['source.php', 'keyword.operator.assignment.php']
+      expect(lines[0][4]).toEqual value: ' ', scopes: ['source.php']
+      expect(lines[0][5]).toEqual value: '<<<', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.begin.php', 'punctuation.definition.string.php']
+      expect(lines[0][6]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.begin.php']
+      expect(lines[0][7]).toEqual value: 'DQL', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.begin.php', 'keyword.operator.nowdoc.php']
+      expect(lines[0][8]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.begin.php']
+      expect(lines[1][0].value).toEqual 'SELECT'
+      expect(lines[1][0].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+      expect(lines[1][1].value).toEqual ' '
+      expect(lines[1][1].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+      expect(lines[1][2].value).toEqual '*'
+      expect(lines[1][2].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+      expect(lines[1][3].value).toEqual ' '
+      expect(lines[1][3].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+      expect(lines[1][4].value).toEqual 'FROM'
+      expect(lines[1][4].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+      expect(lines[1][5].value).toEqual ' table'
+      expect(lines[1][5].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+      expect(lines[2][0]).toEqual value: 'DQL', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.nowdoc.php']
+      expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+
   it 'should tokenize a heredoc with embedded javascript correctly', ->
     waitsForPromise ->
       atom.packages.activatePackage('language-javascript')


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Hello,

This tiny PR adds support for [Doctrine Query Language](https://www.doctrine-project.org/projects/doctrine-orm/en/2.11/reference/dql-doctrine-query-language.html) syntax coloration in heredocs.

Example:

![dql-support](https://user-images.githubusercontent.com/57098/150189952-78e6d5b6-b068-4772-8740-5f08b9be7c54.png)

Thanks!

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
