### PR TITLE
Fix some sql highlighting

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2759,7 +2759,7 @@
     'match': '\\\\(?:\\\\(?:\\\\[\\\\\']?|[^\'])|.)'
     'name': 'constant.character.escape.php'
   'sql-string-double-quoted':
-    'begin': '"\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
+    'begin': '(?i:"\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'
@@ -2828,7 +2828,7 @@
       }
     ]
   'sql-string-single-quoted':
-    'begin': '\'\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
+    'begin': '(?i:\'\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2759,7 +2759,7 @@
     'match': '\\\\(?:\\\\(?:\\\\[\\\\\']?|[^\'])|.)'
     'name': 'constant.character.escape.php'
   'sql-string-double-quoted':
-    'begin': '(?i:"\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
+    'begin': '(?i:"(?=\\s*\\(?\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'
@@ -2828,7 +2828,7 @@
       }
     ]
   'sql-string-single-quoted':
-    'begin': '(?i:\'\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
+    'begin': '(?i:\'(?=\\s*\\(?\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2759,7 +2759,7 @@
     'match': '\\\\(?:\\\\(?:\\\\[\\\\\']?|[^\'])|.)'
     'name': 'constant.character.escape.php'
   'sql-string-double-quoted':
-    'begin': '(?i:"(?=\\s*\\(?\\s*(--\\s*SQL|SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
+    'begin': '(?i:"(?=\\s*\\(?\\s*(--\\s+SQL|SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'
@@ -2828,7 +2828,7 @@
       }
     ]
   'sql-string-single-quoted':
-    'begin': '(?i:\'(?=\\s*\\(?\\s*(--\\s*SQL|SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
+    'begin': '(?i:\'(?=\\s*\\(?\\s*(--\\s+SQL|SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2759,7 +2759,7 @@
     'match': '\\\\(?:\\\\(?:\\\\[\\\\\']?|[^\'])|.)'
     'name': 'constant.character.escape.php'
   'sql-string-double-quoted':
-    'begin': '(?i:"(?=\\s*\\(?\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
+    'begin': '(?i:"(?=\\s*\\(?\\s*(--\\s*SQL|SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'
@@ -2828,7 +2828,7 @@
       }
     ]
   'sql-string-single-quoted':
-    'begin': '(?i:\'(?=\\s*\\(?\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
+    'begin': '(?i:\'(?=\\s*\\(?\\s*(--\\s*SQL|SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2759,7 +2759,7 @@
     'match': '\\\\(?:\\\\(?:\\\\[\\\\\']?|[^\'])|.)'
     'name': 'constant.character.escape.php'
   'sql-string-double-quoted':
-    'begin': '(?i:"(?=\\s*\\(?\\s*(--\\s+SQL|SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
+    'begin': '(?i)"(?=\\s*\\(?\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2828,7 +2828,7 @@
       }
     ]
   'sql-string-single-quoted':
-    'begin': '(?i:\'(?=\\s*\\(?\\s*(--\\s+SQL|SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b))'
+    'begin': '(?i)\'(?=\\s*\\(?\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -2948,6 +2948,24 @@ describe 'PHP grammar', ->
         expect(tokens[2]).toEqual value: ' something', scopes: ['source.php', scope, 'source.sql.embedded.php']
         expect(tokens[3]).toEqual value: delim, scopes: ['source.php', scope, 'punctuation.definition.string.end.php']
 
+        {tokens} = grammar.tokenizeLine "#{delim}sEleCT something#{delim}"
+
+        # Case insensitive
+        expect(tokens[0]).toEqual value: delim, scopes: ['source.php', scope, 'punctuation.definition.string.begin.php']
+        expect(tokens[1]).toEqual value: 'sEleCT', scopes: ['source.php', scope, 'source.sql.embedded.php', 'keyword.other.DML.sql']
+        expect(tokens[2]).toEqual value: ' something', scopes: ['source.php', scope, 'source.sql.embedded.php']
+        expect(tokens[3]).toEqual value: delim, scopes: ['source.php', scope, 'punctuation.definition.string.end.php']
+
+        {tokens} = grammar.tokenizeLine "#{delim}(select something)#{delim}"
+
+        # Surrounded by brackets
+        expect(tokens[0]).toEqual value: delim, scopes: ['source.php', scope, 'punctuation.definition.string.begin.php']
+        expect(tokens[1]).toEqual value: '(', scopes: ['source.php', scope, 'source.sql.embedded.php', 'punctuation.definition.section.bracket.round.begin.sql']
+        expect(tokens[2]).toEqual value: 'select', scopes: ['source.php', scope, 'source.sql.embedded.php', 'keyword.other.DML.sql']
+        expect(tokens[3]).toEqual value: ' something', scopes: ['source.php', scope, 'source.sql.embedded.php']
+        expect(tokens[4]).toEqual value: ')', scopes: ['source.php', scope, 'source.sql.embedded.php', 'punctuation.definition.section.bracket.round.end.sql']
+        expect(tokens[5]).toEqual value: delim, scopes: ['source.php', scope, 'punctuation.definition.string.end.php']
+
         lines = grammar.tokenizeLines """
           #{delim}SELECT something
           -- uh oh a comment SELECT#{delim}


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Combined screenshot of result

Before:

![image](https://user-images.githubusercontent.com/9924643/152641070-638031e2-bde6-4312-9a56-f5a6bff247aa.png)

After (note `$editors` not being highlighted when SQL syntax is applied is a separate issue):

![image](https://user-images.githubusercontent.com/9924643/152641091-0399415d-a868-46f5-8b7f-b5a5afd8ec52.png)


3 main changes to allow for SQL syntax highlighting in strings, in new scenarios.
1. Allows lowercased keywords (e.g. `"select * from users"`)

2. Query starting on next line of string opener (requires `--sql` on opening line). 

3. Query starting with a parenthesis will be allowed in the SQL begin check. (e.g. `"(select 1) union all (select 2)`"

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
1. An alternative to this might be to repeat the same list of keywords in lowercase, so it prevents false positives such as the string "Select from the following:" from being incorrectly highlighted. This doesn't prevent the problem entirely though, and I'm probably still okay making a non-important string have weird colors than to not have this option for people who prefer code to - and I quote - "be screaming at them". 
2. Alternative options were discussed in this thread: https://github.com/atom/language-php/issues/87
Until tree-sitters become a reality, I think having a 'experimental / opt-in' option might make more people happy in the mean time. At least, I would be. An option is better than none / waiting imo. I wouldn't necessarily enforce it throughout the codebase though.
3. Heredocs were proposed but PHPCS might disallow such usage in the first place, and therefore could not be an option.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
More syntax highlighting options for SQL in PHP strings, particularly ones that probably should have worked out of the box (1,2)
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
False positives (1 proposed) - for the string examples mentioned above. 

Otherwise, if it's as the (alternative design 1), this would mean that sPonGebob notation will not be supported. (See https://sqlfum.pt/)

![image](https://user-images.githubusercontent.com/9924643/152640760-f63723bf-787c-4de8-b3c1-319d97c9ea75.png)


### Applicable Issues
https://github.com/atom/language-php/issues/87
https://github.com/atom/language-php/issues/449 (mentions but not its own issue)
<!-- Enter any applicable Issues here -->
