### PR TITLE
Fix spacing in for loop snippet of PHP

### DIFF
--- a/snippets/language-php.cson
+++ b/snippets/language-php.cson
@@ -56,7 +56,7 @@
     'body': 'elseif (${1:condition}) {\n\t${0:// code...}\n}'
   'for …':
     'prefix': 'for'
-    'body': 'for ($${1:i}=${2:0}; $${1:i} < $3; $${1:i}++) {\n\t${0:// code...}\n}'
+    'body': 'for ($${1:i} = ${2:0}; $${1:i} < $3; $${1:i}++) {\n\t${0:// code...}\n}'
   'foreach …':
     'prefix': 'foreach'
     'body': 'foreach ($${1:variable} as $${2:key} ${3:=> $${4:value}}) {\n\t${0:// code...}\n}'


### PR DESCRIPTION
### Description of the Change

Change for loop to a standard style format.

### Alternate Designs

Nothing.

### Benefits

Better compatibilty with [PSR-12](https://www.php-fig.org/psr/psr-12/#62-binary-operators).

### Possible Drawbacks

Nothing.

### Applicable Issues

Nothing.
