### PR TITLE
Improve class definition, add enums

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -15,52 +15,6 @@
     'include': '#comments'
   }
   {
-    'begin': '(?i)^\\s*(interface)\\s+([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)\\s*(extends)?\\s*'
-    'beginCaptures':
-      '1':
-        'name': 'storage.type.interface.php'
-      '2':
-        'name': 'entity.name.type.interface.php'
-      '3':
-        'name': 'storage.modifier.extends.php'
-    'end': '(?i)((?:[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*\\s*,\\s*)*)([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)?\\s*(?:(?={)|$)'
-    'endCaptures':
-      '1':
-        'patterns': [
-          {
-            'match': '(?i)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*'
-            'name': 'entity.other.inherited-class.php'
-          }
-          {
-            'match': ','
-            'name': 'punctuation.separator.classes.php'
-          }
-        ]
-      '2':
-        'name': 'entity.other.inherited-class.php'
-    'name': 'meta.interface.php'
-    'patterns': [
-      {
-        'include': '#namespace'
-      }
-    ]
-  }
-  {
-    'begin': '(?i)^\\s*(trait)\\s+([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)'
-    'beginCaptures':
-      '1':
-        'name': 'storage.type.trait.php'
-      '2':
-        'name': 'entity.name.type.trait.php'
-    'end': '(?={)'
-    'name': 'meta.trait.php'
-    'patterns': [
-      {
-        'include': '#comments'
-      }
-    ]
-  }
-  {
     'match': '(?i)(?:^|(?<=<\\?php))\\s*(namespace)\\s+([a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)(?=\\s*;)'
     'name': 'meta.namespace.php'
     'captures':
@@ -205,6 +159,130 @@
   }
   {
     'begin':  '''(?ix)
+        \\b(trait)\\s+([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)
+      '''
+    'beginCaptures':
+      '1':
+        'name': 'storage.type.trait.php'
+      '2':
+        'name': 'entity.name.type.trait.php'
+    'end': '}|(?=\\?>)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.trait.end.bracket.curly.php'
+    'name': 'meta.trait.php'
+    'patterns': [
+      {
+        'include': '#comments'
+      }
+      {
+        'begin': '{'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.trait.begin.bracket.curly.php'
+        'end': '(?=}|\\?>)'
+        'contentName': 'meta.trait.body.php'
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
+      }
+    ]
+  }
+  {
+    'begin':  '''(?ix)
+        \\b(interface)\\s+([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)
+      '''
+    'beginCaptures':
+      '1':
+        'name': 'storage.type.interface.php'
+      '2':
+        'name': 'entity.name.type.interface.php'
+    'end': '}|(?=\\?>)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.interface.end.bracket.curly.php'
+    'name': 'meta.interface.php'
+    'patterns': [
+      {
+        'include': '#comments'
+      }
+      {
+        'include': '#interface-extends'
+      }
+      {
+        'begin': '{'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.interface.begin.bracket.curly.php'
+        'end': '(?=}|\\?>)'
+        'contentName': 'meta.interface.body.php'
+        'patterns': [
+          {
+            'include': '#class-constant'
+          }
+          {
+            'include': '$self'
+          }
+        ]
+      }
+    ]
+  }
+  {
+    'begin':  '''(?ix)
+        \\b(enum)\\s+([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)
+        (?: \\s* (:) \\s* (int | string) \\b )?
+      '''
+    'beginCaptures':
+      '1':
+        'name': 'storage.type.enum.php'
+      '2':
+        'name': 'entity.name.type.enum.php'
+      '3':
+        'name': 'keyword.operator.return-value.php'
+      '4':
+        'name': 'keyword.other.type.php'
+    'end': '}|(?=\\?>)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.enum.end.bracket.curly.php'
+    'name': 'meta.enum.php'
+    'patterns': [
+      {
+        'include': '#comments'
+      }
+      {
+        'include': '#class-implements'
+      }
+      {
+        'begin': '{'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.enum.begin.bracket.curly.php'
+        'end': '(?=}|\\?>)'
+        'contentName': 'meta.enum.body.php'
+        'patterns': [
+          {
+            'match': '(?i)\\b(case)\\s*([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)'
+            'captures':
+              '1':
+                'name': 'storage.modifier.php'
+              '2':
+                'name': 'constant.enum.php'
+          }
+          {
+            'include': '#class-constant'
+          }
+          {
+            'include': '$self'
+          }
+        ]
+      }
+    ]
+  }
+  {
+    'begin':  '''(?ix)
         (?:
           \\b(?:(abstract|final)\\s+)?(class)\\s+([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)
           |\\b(new)\\b\\s*(\\#\\[.*\\])?\\s*\\b(class)\\b # anonymous class
@@ -234,80 +312,32 @@
     'name': 'meta.class.php'
     'patterns': [
       {
+        'begin': '(?<=class)\\s*(\\()'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.arguments.begin.bracket.round.php'
+        'end': '\\)|(?=\\?>)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.arguments.end.bracket.round.php'
+        'name': 'meta.function-call.php'
+        'patterns': [
+          {
+            'include': '#named-arguments'
+          }
+          {
+            'include': '$self'
+          }
+        ]
+      }
+      {
         'include': '#comments'
       }
       {
-        'begin': '(?i)(extends)\\s+'
-        'beginCaptures':
-          '1':
-            'name': 'storage.modifier.extends.php'
-        'contentName': 'meta.other.inherited-class.php'
-        'end': '(?i)(?=[^a-z0-9_\\x{7f}-\\x{10ffff}\\\\])'
-        'patterns': [
-          {
-            'begin': '(?i)(?=\\\\?[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*\\\\)'
-            'end': '(?i)([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)?(?=[^a-z0-9_\\x{7f}-\\x{10ffff}\\\\])'
-            'endCaptures':
-              '1':
-                'name': 'entity.other.inherited-class.php'
-            'patterns': [
-              {
-                'include': '#namespace'
-              }
-            ]
-          }
-          {
-            'include': '#class-builtin'
-          }
-          {
-            'include': '#namespace'
-          }
-          {
-            'match': '(?i)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*'
-            'name': 'entity.other.inherited-class.php'
-          }
-        ]
+        'include': '#class-extends'
       }
       {
-        'begin': '(?i)(implements)\\s+'
-        'beginCaptures':
-          '1':
-            'name': 'storage.modifier.implements.php'
-        'end': '(?i)(?=[;{])'
-        'patterns': [
-          {
-            'include': '#comments'
-          }
-          {
-            'begin': '(?i)(?=[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)'
-            'contentName': 'meta.other.inherited-class.php'
-            'end': '(?i)(?:\\s*(?:,|(?=[^a-z0-9_\\x{7f}-\\x{10ffff}\\\\\\s]))\\s*)'
-            'patterns': [
-              {
-                'begin': '(?i)(?=\\\\?[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*\\\\)'
-                'end': '(?i)([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)?(?=[^a-z0-9_\\x{7f}-\\x{10ffff}\\\\])'
-                'endCaptures':
-                  '1':
-                    'name': 'entity.other.inherited-class.php'
-                'patterns': [
-                  {
-                    'include': '#namespace'
-                  }
-                ]
-              }
-              {
-                'include': '#class-builtin'
-              }
-              {
-                'include': '#namespace'
-              }
-              {
-                'match': '(?i)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*'
-                'name': 'entity.other.inherited-class.php'
-              }
-            ]
-          }
-        ]
+        'include': '#class-implements'
       }
       {
         'begin': '{'
@@ -317,6 +347,9 @@
         'end': '(?=}|\\?>)'
         'contentName': 'meta.class.body.php'
         'patterns': [
+          {
+            'include': '#class-constant'
+          }
           {
             'include': '$self'
           }
@@ -339,7 +372,6 @@
   }
   {
     'match': '''(?x)
-      \\s* # FIXME: Removing this causes specs to fail. Investigate.
       \\b(
         break|case|continue|declare|default|die|do|
         else(if)?|end(declare|for(each)?|if|switch|while)|exit|
@@ -788,7 +820,7 @@
     'name': 'storage.type.php'
   }
   {
-    'match': '(?i)\\b(global|abstract|const|extends|implements|final|private|protected|public|static)\\b'
+    'match': '(?i)\\b(global|abstract|const|final|private|protected|public|static)\\b'
     'name': 'storage.modifier.php'
   }
   {
@@ -899,7 +931,7 @@
     'captures':
       '1':
         'name': 'entity.name.goto-label.php'
-    'match': '(?i)^\\s*([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)\\s*:(?!:)'
+    'match': '(?i)^\\s*([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*(?<!default))\\s*:(?!:)'
   }
   {
     'include': '#string-backtick'
@@ -1149,6 +1181,104 @@
             'include': '#namespace'
           }
         ]
+      }
+    ]
+  'inheritance-single':
+    'patterns': [
+      {
+        'begin': '(?i)(?=\\\\?[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*\\\\)'
+        'end': '(?i)([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)?(?=[^a-z0-9_\\x{7f}-\\x{10ffff}\\\\])'
+        'endCaptures':
+          '1':
+            'name': 'entity.other.inherited-class.php'
+        'patterns': [
+          {
+            'include': '#namespace'
+          }
+        ]
+      }
+      {
+        'include': '#class-builtin'
+      }
+      {
+        'include': '#namespace'
+      }
+      {
+        'match': '(?i)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*'
+        'name': 'entity.other.inherited-class.php'
+      }
+    ]
+  'class-extends':
+    'patterns': [
+      {
+        'begin': '(?i)(extends)\\s+'
+        'beginCaptures':
+          '1':
+            'name': 'storage.modifier.extends.php'
+        'end': '(?i)(?=[^A-Za-z0-9_\\x{7f}-\\x{10ffff}\\\\])'
+        'patterns': [
+          {
+            'include': '#comments'
+          }
+          {
+            'include': '#inheritance-single'
+          }
+        ]
+      }
+    ]
+  'interface-extends':
+    'patterns': [
+      {
+        'begin': '(?i)(extends)\\s+'
+        'beginCaptures':
+          '1':
+            'name': 'storage.modifier.extends.php'
+        'end': '(?i)(?={)'
+        'patterns': [
+          {
+            'include': '#comments'
+          }
+          {
+            'match': ','
+            'name': 'punctuation.separator.classes.php'
+          }
+          {
+            'include': '#inheritance-single'
+          }
+        ]
+      }
+    ]
+  'class-implements':
+    'patterns': [
+      {
+        'begin': '(?i)(implements)\\s+'
+        'beginCaptures':
+          '1':
+            'name': 'storage.modifier.implements.php'
+        'end': '(?i)(?={)'
+        'patterns': [
+          {
+            'include': '#comments'
+          }
+          {
+            'match': ','
+            'name': 'punctuation.separator.classes.php'
+          }
+          {
+            'include': '#inheritance-single'
+          }
+        ]
+      }
+    ]
+  'class-constant':
+    'patterns': [
+      {
+        'match': '(?i)\\b(const)\\s*([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)'
+        'captures':
+          '1':
+            'name': 'storage.modifier.php'
+          '2':
+            'name': 'constant.other.php'
       }
     ]
   'comments':

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -876,6 +876,28 @@ describe 'PHP grammar', ->
         expect(lines[3][7]).toEqual value: '$', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'variable.other.php', 'punctuation.definition.variable.php']
         expect(lines[3][8]).toEqual value: 'c', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'variable.other.php']
 
+    describe 'consts', ->
+      it 'should tokenize constants with reserved names correctly', ->
+        lines = grammar.tokenizeLines '''
+          class Foo {
+            const Bar = 1;
+            const String = 'one';
+          }
+        '''
+
+        expect(lines[0][0]).toEqual value: 'class', scopes: ['source.php', 'meta.class.php', 'storage.type.class.php']
+        expect(lines[0][2]).toEqual value: 'Foo', scopes: ['source.php', 'meta.class.php', 'entity.name.type.class.php']
+        expect(lines[1][1]).toEqual value: 'const', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'storage.modifier.php']
+        expect(lines[1][3]).toEqual value: 'Bar', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'constant.other.php']
+        expect(lines[1][5]).toEqual value: '=', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'keyword.operator.assignment.php']
+        expect(lines[1][7]).toEqual value: '1', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'constant.numeric.decimal.php']
+        expect(lines[2][1]).toEqual value: 'const', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'storage.modifier.php']
+        expect(lines[2][3]).toEqual value: 'String', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'constant.other.php']
+        expect(lines[2][5]).toEqual value: '=', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'keyword.operator.assignment.php']
+        expect(lines[2][7]).toEqual value: '\'', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'string.quoted.single.php', 'punctuation.definition.string.begin.php']
+        expect(lines[2][8]).toEqual value: 'one', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'string.quoted.single.php']
+        expect(lines[2][9]).toEqual value: '\'', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
+
     describe 'methods', ->
       it 'tokenizes basic method', ->
         lines = grammar.tokenizeLines '''
@@ -1147,9 +1169,173 @@ describe 'PHP grammar', ->
         expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "meta.class.php", "keyword.other.new.php"]
         expect(tokens[7]).toEqual value: 'class', scopes: ["source.php", "meta.class.php", "storage.type.class.php"]
         expect(tokens[9]).toEqual value: 'extends', scopes: ["source.php", "meta.class.php", "storage.modifier.extends.php"]
-        expect(tokens[11]).toEqual value: 'Test', scopes: ["source.php", "meta.class.php", "meta.other.inherited-class.php", "entity.other.inherited-class.php"]
+        expect(tokens[11]).toEqual value: 'Test', scopes: ["source.php", "meta.class.php", "entity.other.inherited-class.php"]
         expect(tokens[13]).toEqual value: 'implements', scopes: ["source.php", "meta.class.php", "storage.modifier.implements.php"]
-        expect(tokens[15]).toEqual value: 'ITest', scopes: ["source.php", "meta.class.php", "meta.other.inherited-class.php", "entity.other.inherited-class.php"]
+        expect(tokens[15]).toEqual value: 'ITest', scopes: ["source.php", "meta.class.php", "entity.other.inherited-class.php"]
+
+      it 'tokenizes constructor arguments correctly', ->
+        {tokens} = grammar.tokenizeLine 'new class(\'string\', optional: 123){}'
+
+        expect(tokens[0]).toEqual value: 'new', scopes: ['source.php', 'meta.class.php', 'keyword.other.new.php']
+        expect(tokens[2]).toEqual value: 'class', scopes: ['source.php', 'meta.class.php', 'storage.type.class.php']
+        expect(tokens[3]).toEqual value: '(', scopes: ['source.php', 'meta.class.php', 'meta.function-call.php', 'punctuation.definition.arguments.begin.bracket.round.php']
+        expect(tokens[4]).toEqual value: '\'', scopes: ['source.php', 'meta.class.php', 'meta.function-call.php', 'string.quoted.single.php', 'punctuation.definition.string.begin.php']
+        expect(tokens[5]).toEqual value: 'string', scopes: ['source.php', 'meta.class.php', 'meta.function-call.php', 'string.quoted.single.php']
+        expect(tokens[6]).toEqual value: '\'', scopes: ['source.php', 'meta.class.php', 'meta.function-call.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
+        expect(tokens[7]).toEqual value: ',', scopes: ['source.php', 'meta.class.php', 'meta.function-call.php', 'punctuation.separator.delimiter.php']
+        expect(tokens[9]).toEqual value: 'optional', scopes: ['source.php', 'meta.class.php', 'meta.function-call.php', 'entity.name.variable.parameter.php']
+        expect(tokens[10]).toEqual value: ':', scopes: ['source.php', 'meta.class.php', 'meta.function-call.php', 'punctuation.separator.colon.php']
+        expect(tokens[12]).toEqual value: '123', scopes: ['source.php', 'meta.class.php', 'meta.function-call.php', 'constant.numeric.decimal.php']
+        expect(tokens[13]).toEqual value: ')', scopes: ['source.php', 'meta.class.php', 'meta.function-call.php', 'punctuation.definition.arguments.end.bracket.round.php']
+
+  describe 'enums', ->
+    it 'should tokenize enums correctly', ->
+      lines = grammar.tokenizeLines '''
+        enum Test {
+          case FOO;
+          case BAR;
+        }
+      '''
+
+      expect(lines[0][0]).toEqual value: 'enum', scopes: ['source.php', 'meta.enum.php', 'storage.type.enum.php']
+      expect(lines[0][2]).toEqual value: 'Test', scopes: ['source.php', 'meta.enum.php', 'entity.name.type.enum.php']
+      expect(lines[0][4]).toEqual value: '{', scopes: ['source.php', 'meta.enum.php', 'punctuation.definition.enum.begin.bracket.curly.php']
+      expect(lines[1][1]).toEqual value: 'case', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'storage.modifier.php']
+      expect(lines[1][3]).toEqual value: 'FOO', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'constant.enum.php']
+      expect(lines[1][4]).toEqual value: ';', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'punctuation.terminator.expression.php']
+      expect(lines[2][1]).toEqual value: 'case', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'storage.modifier.php']
+      expect(lines[2][3]).toEqual value: 'BAR', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'constant.enum.php']
+      expect(lines[2][4]).toEqual value: ';', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'punctuation.terminator.expression.php']
+      expect(lines[3][0]).toEqual value: '}', scopes: ['source.php', 'meta.enum.php', 'punctuation.definition.enum.end.bracket.curly.php']
+
+    it 'should tokenize backed enums correctly', ->
+      lines = grammar.tokenizeLines '''
+        enum HTTPMethods: string {
+          case GET = 'get';
+          case POST = 'post';
+        }
+      '''
+
+      expect(lines[0][0]).toEqual value: 'enum', scopes: ['source.php', 'meta.enum.php', 'storage.type.enum.php']
+      expect(lines[0][2]).toEqual value: 'HTTPMethods', scopes: ['source.php', 'meta.enum.php', 'entity.name.type.enum.php']
+      expect(lines[0][3]).toEqual value: ':', scopes: ['source.php', 'meta.enum.php', 'keyword.operator.return-value.php']
+      expect(lines[0][5]).toEqual value: 'string', scopes: ['source.php', 'meta.enum.php', 'keyword.other.type.php']
+      expect(lines[0][7]).toEqual value: '{', scopes: ['source.php', 'meta.enum.php', 'punctuation.definition.enum.begin.bracket.curly.php']
+      expect(lines[1][1]).toEqual value: 'case', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'storage.modifier.php']
+      expect(lines[1][3]).toEqual value: 'GET', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'constant.enum.php']
+      expect(lines[1][5]).toEqual value: '=', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'keyword.operator.assignment.php']
+      expect(lines[1][7]).toEqual value: '\'', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'string.quoted.single.php', 'punctuation.definition.string.begin.php']
+      expect(lines[1][8]).toEqual value: 'get', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'string.quoted.single.php']
+      expect(lines[1][9]).toEqual value: '\'', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
+      expect(lines[1][10]).toEqual value: ';', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'punctuation.terminator.expression.php']
+      expect(lines[2][1]).toEqual value: 'case', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'storage.modifier.php']
+      expect(lines[2][3]).toEqual value: 'POST', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'constant.enum.php']
+      expect(lines[2][5]).toEqual value: '=', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'keyword.operator.assignment.php']
+      expect(lines[2][7]).toEqual value: '\'', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'string.quoted.single.php', 'punctuation.definition.string.begin.php']
+      expect(lines[2][8]).toEqual value: 'post', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'string.quoted.single.php']
+      expect(lines[2][9]).toEqual value: '\'', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
+      expect(lines[2][10]).toEqual value: ';', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'punctuation.terminator.expression.php']
+      expect(lines[3][0]).toEqual value: '}', scopes: ['source.php', 'meta.enum.php', 'punctuation.definition.enum.end.bracket.curly.php']
+
+    it 'should tokenize enums with method correctly', ->
+      lines = grammar.tokenizeLines '''
+        enum HTTPStatus: int {
+          case OK = 200;
+          case NOT_FOUND = 404;
+
+          public function label(): string {}
+        }
+      '''
+
+      expect(lines[0][0]).toEqual value: 'enum', scopes: ['source.php', 'meta.enum.php', 'storage.type.enum.php']
+      expect(lines[0][2]).toEqual value: 'HTTPStatus', scopes: ['source.php', 'meta.enum.php', 'entity.name.type.enum.php']
+      expect(lines[0][3]).toEqual value: ':', scopes: ['source.php', 'meta.enum.php', 'keyword.operator.return-value.php']
+      expect(lines[0][5]).toEqual value: 'int', scopes: ['source.php', 'meta.enum.php', 'keyword.other.type.php']
+      expect(lines[0][7]).toEqual value: '{', scopes: ['source.php', 'meta.enum.php', 'punctuation.definition.enum.begin.bracket.curly.php']
+      expect(lines[1][1]).toEqual value: 'case', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'storage.modifier.php']
+      expect(lines[1][3]).toEqual value: 'OK', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'constant.enum.php']
+      expect(lines[1][5]).toEqual value: '=', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'keyword.operator.assignment.php']
+      expect(lines[1][7]).toEqual value: '200', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'constant.numeric.decimal.php']
+      expect(lines[2][1]).toEqual value: 'case', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'storage.modifier.php']
+      expect(lines[2][3]).toEqual value: 'NOT_FOUND', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'constant.enum.php']
+      expect(lines[2][5]).toEqual value: '=', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'keyword.operator.assignment.php']
+      expect(lines[2][7]).toEqual value: '404', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'constant.numeric.decimal.php']
+      expect(lines[4][1]).toEqual value: 'public', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.function.php', 'storage.modifier.php']
+      expect(lines[4][3]).toEqual value: 'function', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.function.php', 'storage.type.function.php']
+      expect(lines[4][5]).toEqual value: 'label', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.function.php', 'entity.name.function.php']
+      expect(lines[4][6]).toEqual value: '(', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
+      expect(lines[4][7]).toEqual value: ')', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
+      expect(lines[4][8]).toEqual value: ':', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.function.php', 'keyword.operator.return-value.php']
+      expect(lines[4][10]).toEqual value: 'string', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.function.php', 'keyword.other.type.php']
+      expect(lines[5][0]).toEqual value: '}', scopes: ['source.php', 'meta.enum.php', 'punctuation.definition.enum.end.bracket.curly.php']
+
+    it 'should tokenize enums implementing interfaces correctly', ->
+      {tokens} = grammar.tokenizeLine 'enum FooEnum implements Foo {}'
+
+      expect(tokens[0]).toEqual value: 'enum', scopes: ['source.php', 'meta.enum.php', 'storage.type.enum.php']
+      expect(tokens[2]).toEqual value: 'FooEnum', scopes: ['source.php', 'meta.enum.php', 'entity.name.type.enum.php']
+      expect(tokens[4]).toEqual value: 'implements', scopes: ['source.php', 'meta.enum.php', 'storage.modifier.implements.php']
+      expect(tokens[6]).toEqual value: 'Foo', scopes: ['source.php', 'meta.enum.php', 'entity.other.inherited-class.php']
+      expect(tokens[8]).toEqual value: '{', scopes: ['source.php', 'meta.enum.php', 'punctuation.definition.enum.begin.bracket.curly.php']
+      expect(tokens[9]).toEqual value: '}', scopes: ['source.php', 'meta.enum.php', 'punctuation.definition.enum.end.bracket.curly.php']
+
+    it 'should tokenize switch in enum correctly', ->
+      lines = grammar.tokenizeLines '''
+        enum Foo {
+          case One;
+          public function test() {
+            switch(One){
+              case One:
+            }
+          }
+        }
+      '''
+
+      expect(lines[0][0]).toEqual value: 'enum', scopes: ['source.php', 'meta.enum.php', 'storage.type.enum.php']
+      expect(lines[0][2]).toEqual value: 'Foo', scopes: ['source.php', 'meta.enum.php', 'entity.name.type.enum.php']
+      expect(lines[1][1]).toEqual value: 'case', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'storage.modifier.php']
+      expect(lines[1][3]).toEqual value: 'One', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'constant.enum.php']
+      expect(lines[2][3]).toEqual value: 'function', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.function.php', 'storage.type.function.php']
+      expect(lines[2][5]).toEqual value: 'test', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.function.php', 'entity.name.function.php']
+      expect(lines[2][6]).toEqual value: '(', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
+      expect(lines[2][7]).toEqual value: ')', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
+      expect(lines[2][9]).toEqual value: '{', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'punctuation.definition.begin.bracket.curly.php']
+      expect(lines[3][1]).toEqual value: 'switch', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.switch-statement.php', 'keyword.control.switch.php']
+      expect(lines[3][2]).toEqual value: '(', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.switch-statement.php', 'punctuation.definition.switch-expression.begin.bracket.round.php']
+      expect(lines[3][3]).toEqual value: 'One', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.switch-statement.php', 'constant.other.php']
+      expect(lines[3][4]).toEqual value: ')', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.switch-statement.php', 'punctuation.definition.switch-expression.end.bracket.round.php']
+      expect(lines[3][5]).toEqual value: '{', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.switch-statement.php', 'punctuation.definition.section.switch-block.begin.bracket.curly.php']
+      expect(lines[4][1]).toEqual value: 'case', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.switch-statement.php', 'keyword.control.case.php']
+      expect(lines[4][3]).toEqual value: 'One', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.switch-statement.php', 'constant.other.php']
+      expect(lines[4][4]).toEqual value: ':', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.switch-statement.php', 'punctuation.terminator.statement.php']
+      expect(lines[5][1]).toEqual value: '}', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'meta.switch-statement.php', 'punctuation.definition.section.switch-block.end.bracket.curly.php']
+      expect(lines[6][1]).toEqual value: '}', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'punctuation.definition.end.bracket.curly.php']
+      expect(lines[7][0]).toEqual value: '}', scopes: ['source.php', 'meta.enum.php', 'punctuation.definition.enum.end.bracket.curly.php']
+
+    it 'should tokenize constants in enums correctly', ->
+      lines = grammar.tokenizeLines '''
+        enum Foo : int {
+          case Bar = 1;
+          const Baz = 1;
+        }
+      '''
+
+      expect(lines[0][0]).toEqual value: 'enum', scopes: ['source.php', 'meta.enum.php', 'storage.type.enum.php']
+      expect(lines[0][2]).toEqual value: 'Foo', scopes: ['source.php', 'meta.enum.php', 'entity.name.type.enum.php']
+      expect(lines[0][4]).toEqual value: ':', scopes: ['source.php', 'meta.enum.php', 'keyword.operator.return-value.php']
+      expect(lines[0][6]).toEqual value: 'int', scopes: ['source.php', 'meta.enum.php', 'keyword.other.type.php']
+      expect(lines[0][8]).toEqual value: '{', scopes: ['source.php', 'meta.enum.php', 'punctuation.definition.enum.begin.bracket.curly.php']
+      expect(lines[1][1]).toEqual value: 'case', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'storage.modifier.php']
+      expect(lines[1][3]).toEqual value: 'Bar', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'constant.enum.php']
+      expect(lines[1][5]).toEqual value: '=', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'keyword.operator.assignment.php']
+      expect(lines[1][7]).toEqual value: '1', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'constant.numeric.decimal.php']
+      expect(lines[1][8]).toEqual value: ';', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'punctuation.terminator.expression.php']
+      expect(lines[2][1]).toEqual value: 'const', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'storage.modifier.php']
+      expect(lines[2][3]).toEqual value: 'Baz', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'constant.other.php']
+      expect(lines[2][5]).toEqual value: '=', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'keyword.operator.assignment.php']
+      expect(lines[2][7]).toEqual value: '1', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'constant.numeric.decimal.php']
+      expect(lines[2][8]).toEqual value: ';', scopes: ['source.php', 'meta.enum.php', 'meta.enum.body.php', 'punctuation.terminator.expression.php']
+      expect(lines[3][0]).toEqual value: '}', scopes: ['source.php', 'meta.enum.php', 'punctuation.definition.enum.end.bracket.curly.php']
 
   describe 'functions', ->
     it 'tokenizes functions with no arguments', ->
@@ -2825,8 +3011,8 @@ describe 'PHP grammar', ->
     expect(tokens[8]).toEqual value: ' ', scopes: ['source.php', 'meta.interface.php']
     expect(tokens[9]).toEqual value: 'Plane', scopes: ['source.php', 'meta.interface.php', 'entity.other.inherited-class.php']
     expect(tokens[10]).toEqual value: ' ', scopes: ['source.php', 'meta.interface.php']
-    expect(tokens[11]).toEqual value: '{', scopes: ['source.php', 'punctuation.definition.begin.bracket.curly.php']
-    expect(tokens[12]).toEqual value: '}', scopes: ['source.php', 'punctuation.definition.end.bracket.curly.php']
+    expect(tokens[11]).toEqual value: '{', scopes: ['source.php', 'meta.interface.php', 'punctuation.definition.interface.begin.bracket.curly.php']
+    expect(tokens[12]).toEqual value: '}', scopes: ['source.php', 'meta.interface.php', 'punctuation.definition.interface.end.bracket.curly.php']
 
   it 'should tokenize methods in interface correctly', ->
     lines = grammar.tokenizeLines '''
@@ -2838,20 +3024,20 @@ describe 'PHP grammar', ->
 
     expect(lines[0][0]).toEqual value: 'interface', scopes: ['source.php', 'meta.interface.php', 'storage.type.interface.php']
     expect(lines[0][2]).toEqual value: 'Test', scopes: ['source.php', 'meta.interface.php', 'entity.name.type.interface.php']
-    expect(lines[0][4]).toEqual value: '{', scopes: ['source.php', 'punctuation.definition.begin.bracket.curly.php']
-    expect(lines[1][1]).toEqual value: 'public', scopes: ['source.php', 'meta.function.php', 'storage.modifier.php']
-    expect(lines[1][3]).toEqual value: 'function', scopes: ['source.php', 'meta.function.php', 'storage.type.function.php']
-    expect(lines[1][5]).toEqual value: 'testMethod', scopes: ['source.php', 'meta.function.php', 'entity.name.function.php']
-    expect(lines[1][6]).toEqual value: '(', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
-    expect(lines[1][7]).toEqual value: ')', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
-    expect(lines[1][8]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
-    expect(lines[2][1]).toEqual value: 'public', scopes: ['source.php', 'meta.function.php', 'storage.modifier.php']
-    expect(lines[2][3]).toEqual value: 'function', scopes: ['source.php', 'meta.function.php', 'storage.type.function.php']
-    expect(lines[2][5]).toEqual value: '__toString', scopes: ['source.php', 'meta.function.php', 'support.function.magic.php']
-    expect(lines[2][6]).toEqual value: '(', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
-    expect(lines[2][7]).toEqual value: ')', scopes: ['source.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
-    expect(lines[2][8]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
-    expect(lines[3][0]).toEqual value: '}', scopes: ['source.php', 'punctuation.definition.end.bracket.curly.php']
+    expect(lines[0][4]).toEqual value: '{', scopes: ['source.php', 'meta.interface.php', 'punctuation.definition.interface.begin.bracket.curly.php']
+    expect(lines[1][1]).toEqual value: 'public', scopes: ['source.php', 'meta.interface.php', 'meta.interface.body.php', 'meta.function.php', 'storage.modifier.php']
+    expect(lines[1][3]).toEqual value: 'function', scopes: ['source.php', 'meta.interface.php', 'meta.interface.body.php', 'meta.function.php', 'storage.type.function.php']
+    expect(lines[1][5]).toEqual value: 'testMethod', scopes: ['source.php', 'meta.interface.php', 'meta.interface.body.php', 'meta.function.php', 'entity.name.function.php']
+    expect(lines[1][6]).toEqual value: '(', scopes: ['source.php', 'meta.interface.php', 'meta.interface.body.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
+    expect(lines[1][7]).toEqual value: ')', scopes: ['source.php', 'meta.interface.php', 'meta.interface.body.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
+    expect(lines[1][8]).toEqual value: ';', scopes: ['source.php', 'meta.interface.php', 'meta.interface.body.php', 'punctuation.terminator.expression.php']
+    expect(lines[2][1]).toEqual value: 'public', scopes: ['source.php', 'meta.interface.php', 'meta.interface.body.php', 'meta.function.php', 'storage.modifier.php']
+    expect(lines[2][3]).toEqual value: 'function', scopes: ['source.php', 'meta.interface.php', 'meta.interface.body.php', 'meta.function.php', 'storage.type.function.php']
+    expect(lines[2][5]).toEqual value: '__toString', scopes: ['source.php', 'meta.interface.php', 'meta.interface.body.php', 'meta.function.php', 'support.function.magic.php']
+    expect(lines[2][6]).toEqual value: '(', scopes: ['source.php', 'meta.interface.php', 'meta.interface.body.php', 'meta.function.php', 'punctuation.definition.parameters.begin.bracket.round.php']
+    expect(lines[2][7]).toEqual value: ')', scopes: ['source.php', 'meta.interface.php', 'meta.interface.body.php', 'meta.function.php', 'punctuation.definition.parameters.end.bracket.round.php']
+    expect(lines[2][8]).toEqual value: ';', scopes: ['source.php', 'meta.interface.php', 'meta.interface.body.php', 'punctuation.terminator.expression.php']
+    expect(lines[3][0]).toEqual value: '}', scopes: ['source.php', 'meta.interface.php', 'punctuation.definition.interface.end.bracket.curly.php']
 
   it 'should tokenize trait correctly', ->
     {tokens} = grammar.tokenizeLine 'trait Test {}'
@@ -2860,8 +3046,8 @@ describe 'PHP grammar', ->
     expect(tokens[1]).toEqual value: ' ', scopes: ['source.php', 'meta.trait.php']
     expect(tokens[2]).toEqual value: 'Test', scopes: ['source.php', 'meta.trait.php', 'entity.name.type.trait.php']
     expect(tokens[3]).toEqual value: ' ', scopes: ['source.php', 'meta.trait.php']
-    expect(tokens[4]).toEqual value: '{', scopes: ['source.php', 'punctuation.definition.begin.bracket.curly.php']
-    expect(tokens[5]).toEqual value: '}', scopes: ['source.php', 'punctuation.definition.end.bracket.curly.php']
+    expect(tokens[4]).toEqual value: '{', scopes: ['source.php', 'meta.trait.php', 'punctuation.definition.trait.begin.bracket.curly.php']
+    expect(tokens[5]).toEqual value: '}', scopes: ['source.php', 'meta.trait.php', 'punctuation.definition.trait.end.bracket.curly.php']
 
   it 'should tokenize use const correctly', ->
     {tokens} = grammar.tokenizeLine 'use const Test\\Test\\CONSTANT;'


### PR DESCRIPTION
Changes:
- Reimplemented class definition:
  - Allow new lines before `extends` and `implements` #414 
  - Tokenize fqn and build-in classes in inheritance (e.g. `Foo\Bar`)
  - New `meta.*.body.php` token for trait/interface body, similar to class
  - Tokenize constructor arguments in anonymous classes
  - Tokenize constant names using reserved word (e.g. `const STRING = 'test';`) #390 (3rd point)
- Support for enums https://wiki.php.net/rfc/enumerations

fix #414, fix microsoft/vscode#116103, fix #451, fix microsoft/vscode#142824, fix #390 (3rd point - last remaining)
closes #428 (php 8.1 complete)

/cc @darangi 