### PR TITLE
Allow named arguments in constructors

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2316,36 +2316,59 @@
       }
     ]
   'instantiation':
-    'begin': '(?i)(new)\\s+(?!class\\b)([a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)\\s*(\\()'
-    'beginCaptures':
-      '1':
-        'name': 'keyword.other.new.php'
-      '2':
-        'patterns': [
-          {
-            'match': '(?i)(parent|static|self)(?![a-z0-9_\\x{7f}-\\x{10ffff}])'
-            'name': 'storage.type.php'
-          }
-          {
-            'include': '#class-name'
-          }
-          {
-            'include': '#variable-name'
-          }
-        ]
-      '3':
-        'name': 'punctuation.definition.arguments.begin.bracket.round.php'
-    'end': '\\)'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.arguments.end.bracket.round.php'
-    'name': 'meta.instantiation.php'
     'patterns': [
       {
-        'include': '#named-arguments'
-      }
+        'match': '(?i)(new)\\s+(?!class\\b)([$a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)(?![a-z0-9_\\x{7f}-\\x{10ffff}\\\\(])'
+        'captures':
+          '1':
+            'name': 'keyword.other.new.php'
+          '2':
+            'patterns': [
+              {
+                'match': '(?i)(parent|static|self)(?![a-z0-9_\\x{7f}-\\x{10ffff}])'
+                'name': 'storage.type.php'
+              }
+              {
+                'include': '#class-name'
+              }
+              {
+                'include': '#variable-name'
+              }
+            ]
+      },
       {
-        'include': '$self'
+        'begin': '(?i)(new)\\s+(?!class\\b)([$a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)\\s*(\\()'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.other.new.php'
+          '2':
+            'patterns': [
+              {
+                'match': '(?i)(parent|static|self)(?![a-z0-9_\\x{7f}-\\x{10ffff}])'
+                'name': 'storage.type.php'
+              }
+              {
+                'include': '#class-name'
+              }
+              {
+                'include': '#variable-name'
+              }
+            ]
+          '3':
+            'name': 'punctuation.definition.arguments.begin.bracket.round.php'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.arguments.end.bracket.round.php'
+        'contentName': 'meta.function-call.php'
+        'patterns': [
+          {
+            'include': '#named-arguments'
+          }
+          {
+            'include': '$self'
+          }
+        ]
       }
     ]
   'interpolation':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2315,7 +2315,7 @@
             'name': 'keyword.operator.nowdoc.php'
       }
     ]
-  'instantiation':
+  'instantiation1':
     'begin': '(?i)(new)\\s+(?!class\\b)'
     'beginCaptures':
       '1':
@@ -2331,6 +2331,39 @@
       }
       {
         'include': '#variable-name'
+      }
+    ]
+  'instantiation':
+    'begin': '(?i)(new)\\s+(?!class\\b)([a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)\\s*(\\()'
+    'beginCaptures':
+      '1':
+        'name': 'keyword.other.new.php'
+      '2':
+        'patterns': [
+          {
+            'match': '(?i)(parent|static|self)(?![a-z0-9_\\x{7f}-\\x{10ffff}])'
+            'name': 'storage.type.php'
+          }
+          {
+            'include': '#class-name'
+          }
+          {
+            'include': '#variable-name'
+          }
+        ]
+      '3':
+        'name': 'punctuation.definition.arguments.begin.bracket.round.php'
+    'end': '\\)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.arguments.end.bracket.round.php'
+    'name': 'meta.instantiation.php'
+    'patterns': [
+      {
+        'include': '#named-arguments'
+      }
+      {
+        'include': '$self'
       }
     ]
   'interpolation':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2315,24 +2315,6 @@
             'name': 'keyword.operator.nowdoc.php'
       }
     ]
-  'instantiation1':
-    'begin': '(?i)(new)\\s+(?!class\\b)'
-    'beginCaptures':
-      '1':
-        'name': 'keyword.other.new.php'
-    'end': '(?i)(?=[^a-z0-9_\\x{7f}-\\x{10ffff}\\\\])'
-    'patterns': [
-      {
-        'match': '(?i)(parent|static|self)(?![a-z0-9_\\x{7f}-\\x{10ffff}])'
-        'name': 'storage.type.php'
-      }
-      {
-        'include': '#class-name'
-      }
-      {
-        'include': '#variable-name'
-      }
-    ]
   'instantiation':
     'begin': '(?i)(new)\\s+(?!class\\b)([a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)\\s*(\\()'
     'beginCaptures':

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -698,12 +698,29 @@ describe 'PHP grammar', ->
     it 'tokenizes class instantiation', ->
       {tokens} = grammar.tokenizeLine '$a = new ClassName();'
 
-      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "keyword.other.new.php"]
-      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php"]
-      expect(tokens[7]).toEqual value: 'ClassName', scopes: ["source.php", "support.class.php"]
-      expect(tokens[8]).toEqual value: '(', scopes: ["source.php", "punctuation.definition.begin.bracket.round.php"]
-      expect(tokens[9]).toEqual value: ')', scopes: ["source.php", "punctuation.definition.end.bracket.round.php"]
+      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "meta.instantiation.php", "keyword.other.new.php"]
+      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php", "meta.instantiation.php"]
+      expect(tokens[7]).toEqual value: 'ClassName', scopes: ["source.php", "meta.instantiation.php", "support.class.php"]
+      expect(tokens[8]).toEqual value: '(', scopes: ["source.php", "meta.instantiation.php", "punctuation.definition.arguments.begin.bracket.round.php"]
+      expect(tokens[9]).toEqual value: ')', scopes: ["source.php", "meta.instantiation.php", "punctuation.definition.arguments.end.bracket.round.php"]
       expect(tokens[10]).toEqual value: ';', scopes: ["source.php", "punctuation.terminator.expression.php"]
+
+    it 'tokenizes class instantiation with arguments', ->
+      {tokens} = grammar.tokenizeLine '$a = new ClassName(5, x: 123);'
+
+      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "meta.instantiation.php", "keyword.other.new.php"]
+      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php", "meta.instantiation.php"]
+      expect(tokens[7]).toEqual value: 'ClassName', scopes: ["source.php", "meta.instantiation.php", "support.class.php"]
+      expect(tokens[8]).toEqual value: '(', scopes: ["source.php", "meta.instantiation.php", "punctuation.definition.arguments.begin.bracket.round.php"]
+      expect(tokens[9]).toEqual value: '5', scopes: ['source.php', "meta.instantiation.php", 'constant.numeric.decimal.php']
+      expect(tokens[10]).toEqual value: ',', scopes: ['source.php', "meta.instantiation.php", 'punctuation.separator.delimiter.php']
+      expect(tokens[11]).toEqual value: ' ', scopes: ['source.php', "meta.instantiation.php"]
+      expect(tokens[12]).toEqual value: 'x', scopes: ['source.php', "meta.instantiation.php", 'entity.name.variable.parameter.php']
+      expect(tokens[13]).toEqual value: ':', scopes: ['source.php', "meta.instantiation.php", 'punctuation.separator.colon.php']
+      expect(tokens[14]).toEqual value: ' ', scopes: ['source.php', "meta.instantiation.php"]
+      expect(tokens[15]).toEqual value: '123', scopes: ['source.php', "meta.instantiation.php", 'constant.numeric.decimal.php']
+      expect(tokens[16]).toEqual value: ')', scopes: ["source.php", "meta.instantiation.php", "punctuation.definition.arguments.end.bracket.round.php"]
+      expect(tokens[17]).toEqual value: ';', scopes: ["source.php", "punctuation.terminator.expression.php"]
 
     it 'tokenizes class modifiers', ->
       {tokens} = grammar.tokenizeLine 'abstract class Test {}'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -698,28 +698,56 @@ describe 'PHP grammar', ->
     it 'tokenizes class instantiation', ->
       {tokens} = grammar.tokenizeLine '$a = new ClassName();'
 
-      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "meta.instantiation.php", "keyword.other.new.php"]
-      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php", "meta.instantiation.php"]
-      expect(tokens[7]).toEqual value: 'ClassName', scopes: ["source.php", "meta.instantiation.php", "support.class.php"]
-      expect(tokens[8]).toEqual value: '(', scopes: ["source.php", "meta.instantiation.php", "punctuation.definition.arguments.begin.bracket.round.php"]
-      expect(tokens[9]).toEqual value: ')', scopes: ["source.php", "meta.instantiation.php", "punctuation.definition.arguments.end.bracket.round.php"]
+      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "keyword.other.new.php"]
+      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php"]
+      expect(tokens[7]).toEqual value: 'ClassName', scopes: ["source.php", "support.class.php"]
+      expect(tokens[8]).toEqual value: '(', scopes: ["source.php", "punctuation.definition.arguments.begin.bracket.round.php"]
+      expect(tokens[9]).toEqual value: ')', scopes: ["source.php", "punctuation.definition.arguments.end.bracket.round.php"]
       expect(tokens[10]).toEqual value: ';', scopes: ["source.php", "punctuation.terminator.expression.php"]
+
+    it 'tokenizes class instantiation with a variable', ->
+      {tokens} = grammar.tokenizeLine '$a = new $b();'
+
+      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "keyword.other.new.php"]
+      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php"]
+      expect(tokens[7]).toEqual value: '$', scopes: ["source.php", "variable.other.php", "punctuation.definition.variable.php"]
+      expect(tokens[8]).toEqual value: 'b', scopes: ["source.php", "variable.other.php"]
+      expect(tokens[9]).toEqual value: '(', scopes: ["source.php", "punctuation.definition.arguments.begin.bracket.round.php"]
+      expect(tokens[10]).toEqual value: ')', scopes: ["source.php", "punctuation.definition.arguments.end.bracket.round.php"]
+      expect(tokens[11]).toEqual value: ';', scopes: ["source.php", "punctuation.terminator.expression.php"]
+
+    it 'tokenizes class instantiation with no brackets', ->
+      {tokens} = grammar.tokenizeLine '$a = new ClassName;'
+
+      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "keyword.other.new.php"]
+      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php"]
+      expect(tokens[7]).toEqual value: 'ClassName', scopes: ["source.php", "support.class.php"]
+      expect(tokens[8]).toEqual value: ';', scopes: ["source.php", "punctuation.terminator.expression.php"]
+
+    it 'tokenizes class instantiation with a variable with no brackets', ->
+      {tokens} = grammar.tokenizeLine '$a = new $b;'
+
+      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "keyword.other.new.php"]
+      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php"]
+      expect(tokens[7]).toEqual value: '$', scopes: ["source.php", "variable.other.php", "punctuation.definition.variable.php"]
+      expect(tokens[8]).toEqual value: 'b', scopes: ["source.php", "variable.other.php"]
+      expect(tokens[9]).toEqual value: ';', scopes: ["source.php", "punctuation.terminator.expression.php"]
 
     it 'tokenizes class instantiation with arguments', ->
       {tokens} = grammar.tokenizeLine '$a = new ClassName(5, x: 123);'
 
-      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "meta.instantiation.php", "keyword.other.new.php"]
-      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php", "meta.instantiation.php"]
-      expect(tokens[7]).toEqual value: 'ClassName', scopes: ["source.php", "meta.instantiation.php", "support.class.php"]
-      expect(tokens[8]).toEqual value: '(', scopes: ["source.php", "meta.instantiation.php", "punctuation.definition.arguments.begin.bracket.round.php"]
-      expect(tokens[9]).toEqual value: '5', scopes: ['source.php', "meta.instantiation.php", 'constant.numeric.decimal.php']
-      expect(tokens[10]).toEqual value: ',', scopes: ['source.php', "meta.instantiation.php", 'punctuation.separator.delimiter.php']
-      expect(tokens[11]).toEqual value: ' ', scopes: ['source.php', "meta.instantiation.php"]
-      expect(tokens[12]).toEqual value: 'x', scopes: ['source.php', "meta.instantiation.php", 'entity.name.variable.parameter.php']
-      expect(tokens[13]).toEqual value: ':', scopes: ['source.php', "meta.instantiation.php", 'punctuation.separator.colon.php']
-      expect(tokens[14]).toEqual value: ' ', scopes: ['source.php', "meta.instantiation.php"]
-      expect(tokens[15]).toEqual value: '123', scopes: ['source.php', "meta.instantiation.php", 'constant.numeric.decimal.php']
-      expect(tokens[16]).toEqual value: ')', scopes: ["source.php", "meta.instantiation.php", "punctuation.definition.arguments.end.bracket.round.php"]
+      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "keyword.other.new.php"]
+      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php"]
+      expect(tokens[7]).toEqual value: 'ClassName', scopes: ["source.php", "support.class.php"]
+      expect(tokens[8]).toEqual value: '(', scopes: ["source.php", "punctuation.definition.arguments.begin.bracket.round.php"]
+      expect(tokens[9]).toEqual value: '5', scopes: ['source.php', "meta.function-call.php", 'constant.numeric.decimal.php']
+      expect(tokens[10]).toEqual value: ',', scopes: ['source.php', "meta.function-call.php", 'punctuation.separator.delimiter.php']
+      expect(tokens[11]).toEqual value: ' ', scopes: ['source.php', "meta.function-call.php"]
+      expect(tokens[12]).toEqual value: 'x', scopes: ['source.php', "meta.function-call.php", 'entity.name.variable.parameter.php']
+      expect(tokens[13]).toEqual value: ':', scopes: ['source.php', "meta.function-call.php", 'punctuation.separator.colon.php']
+      expect(tokens[14]).toEqual value: ' ', scopes: ['source.php', "meta.function-call.php"]
+      expect(tokens[15]).toEqual value: '123', scopes: ['source.php', "meta.function-call.php", 'constant.numeric.decimal.php']
+      expect(tokens[16]).toEqual value: ')', scopes: ["source.php", "punctuation.definition.arguments.end.bracket.round.php"]
       expect(tokens[17]).toEqual value: ';', scopes: ["source.php", "punctuation.terminator.expression.php"]
 
     it 'tokenizes class modifiers', ->

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -695,6 +695,60 @@ describe 'PHP grammar', ->
       expect(tokens[6]).toEqual value: '/*', scopes: ['source.php', 'meta.class.php', 'meta.class.body.php', 'comment.block.php', 'punctuation.definition.comment.php']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.php', 'meta.class.php', 'punctuation.definition.class.end.bracket.curly.php']
 
+    it 'tokenizes class instantiation with special name "parent" without brackets', ->
+      {tokens} = grammar.tokenizeLine '$a = new parent;'
+
+      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "keyword.other.new.php"]
+      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php"]
+      expect(tokens[7]).toEqual value: 'parent', scopes: ["source.php", "storage.type.php"]
+      expect(tokens[8]).toEqual value: ';', scopes: ["source.php", "punctuation.terminator.expression.php"]
+
+    it 'tokenizes class instantiation with special name "parent" with brackets', ->
+      {tokens} = grammar.tokenizeLine '$a = new parent();'
+
+      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "keyword.other.new.php"]
+      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php"]
+      expect(tokens[7]).toEqual value: 'parent', scopes: ["source.php", "storage.type.php"]
+      expect(tokens[8]).toEqual value: '(', scopes: ["source.php", "punctuation.definition.arguments.begin.bracket.round.php"]
+      expect(tokens[9]).toEqual value: ')', scopes: ["source.php", "punctuation.definition.arguments.end.bracket.round.php"]
+      expect(tokens[10]).toEqual value: ';', scopes: ["source.php", "punctuation.terminator.expression.php"]
+
+    it 'tokenizes class instantiation with special name "self" without brackets', ->
+      {tokens} = grammar.tokenizeLine '$a = new self;'
+
+      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "keyword.other.new.php"]
+      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php"]
+      expect(tokens[7]).toEqual value: 'self', scopes: ["source.php", "storage.type.php"]
+      expect(tokens[8]).toEqual value: ';', scopes: ["source.php", "punctuation.terminator.expression.php"]
+
+    it 'tokenizes class instantiation with special name "self" with brackets', ->
+      {tokens} = grammar.tokenizeLine '$a = new self();'
+
+      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "keyword.other.new.php"]
+      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php"]
+      expect(tokens[7]).toEqual value: 'self', scopes: ["source.php", "storage.type.php"]
+      expect(tokens[8]).toEqual value: '(', scopes: ["source.php", "punctuation.definition.arguments.begin.bracket.round.php"]
+      expect(tokens[9]).toEqual value: ')', scopes: ["source.php", "punctuation.definition.arguments.end.bracket.round.php"]
+      expect(tokens[10]).toEqual value: ';', scopes: ["source.php", "punctuation.terminator.expression.php"]
+
+    it 'tokenizes class instantiation with special name "static" without brackets', ->
+      {tokens} = grammar.tokenizeLine '$a = new static;'
+
+      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "keyword.other.new.php"]
+      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php"]
+      expect(tokens[7]).toEqual value: 'static', scopes: ["source.php", "storage.type.php"]
+      expect(tokens[8]).toEqual value: ';', scopes: ["source.php", "punctuation.terminator.expression.php"]
+
+    it 'tokenizes class instantiation with special name "static" with brackets', ->
+      {tokens} = grammar.tokenizeLine '$a = new static();'
+
+      expect(tokens[5]).toEqual value: 'new', scopes: ["source.php", "keyword.other.new.php"]
+      expect(tokens[6]).toEqual value: ' ', scopes: ["source.php"]
+      expect(tokens[7]).toEqual value: 'static', scopes: ["source.php", "storage.type.php"]
+      expect(tokens[8]).toEqual value: '(', scopes: ["source.php", "punctuation.definition.arguments.begin.bracket.round.php"]
+      expect(tokens[9]).toEqual value: ')', scopes: ["source.php", "punctuation.definition.arguments.end.bracket.round.php"]
+      expect(tokens[10]).toEqual value: ';', scopes: ["source.php", "punctuation.terminator.expression.php"]
+
     it 'tokenizes class instantiation', ->
       {tokens} = grammar.tokenizeLine '$a = new ClassName();'
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Changes "instantiation" pattern to allow for named parameters when instantiating objects.

### Alternate Designs

I didn't find any other alternatives than changing the "instantiation" pattern.

### Benefits

The names of the parameters will be tokenized in constructors.

### Possible Drawbacks

Can't see any.

### Applicable Issues

No applicable issues that I know of.
