### PR TITLE
SQL string with \n \r or \t prefixed

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2889,7 +2889,7 @@
     'match': '\\\\(?:\\\\(?:\\\\[\\\\\']?|[^\'])|.)'
     'name': 'constant.character.escape.php'
   'sql-string-double-quoted':
-    'begin': '"\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
+    'begin': '"[\\s\\n\\r\\t]*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'
@@ -2958,7 +2958,7 @@
       }
     ]
   'sql-string-single-quoted':
-    'begin': '\'\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
+    'begin': '\'[\\s\\n\\r\\t]*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Identify SQL string with \n, \r or \t prefixed.

### Benefits

Will identify SQL string with \n, \r or \t prefixed as in the following example:

```php
DB::select("
    SELECT 1
");
```

### Possible Drawbacks

None

### Applicable Issues

None open
